### PR TITLE
Make createDimensions method protected

### DIFF
--- a/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
+++ b/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
@@ -129,7 +129,7 @@ public class CloudWatchMetricObserver extends BaseMetricObserver {
         //TODO Need to convert into reasonable units based on DataType
     }
 
-    List<Dimension> createDimensions(TagList tags) {
+    protected List<Dimension> createDimensions(TagList tags) {
         List<Dimension> dimensionList = new ArrayList<Dimension>(tags.size());
 
         for (Tag tag : tags) {


### PR DESCRIPTION
...dWatchMetricObserver.java

Make createDimensions method protected so that one can override this
without voilating package structure. User should be able to add
more dimensions or additional tags like AWS instance when doing JMX 
polling.
