### PR TITLE
Allow setting timestamp on metrics.

### DIFF
--- a/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
+++ b/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
@@ -29,6 +29,7 @@ import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
 
 import com.google.common.base.Preconditions;
 
+import com.netflix.servo.tag.StandardTagKeys;
 import com.netflix.servo.tag.Tag;
 import com.netflix.servo.tag.TagList;
 
@@ -133,7 +134,11 @@ public class CloudWatchMetricObserver extends BaseMetricObserver {
         List<Dimension> dimensionList = new ArrayList<Dimension>(tags.size());
 
         for (Tag tag : tags) {
-            dimensionList.add(new Dimension().withName(tag.getKey()).withValue(tag.getValue()));
+            // Filter out timestamp tags since that will result in unique dimensions for each
+            // datapoint in the AWS console
+            if (!tag.getKey().equals(StandardTagKeys.TIMESTAMP.getKeyName())) {
+                dimensionList.add(new Dimension().withName(tag.getKey()).withValue(tag.getValue()));
+            }
         }
 
         return dimensionList;

--- a/servo-core/src/main/java/com/netflix/servo/examples/DynamicExample.java
+++ b/servo-core/src/main/java/com/netflix/servo/examples/DynamicExample.java
@@ -1,0 +1,40 @@
+package com.netflix.servo.examples;
+
+import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.monitor.Monitor;
+import com.netflix.servo.monitor.MonitorConfig;
+import com.netflix.servo.tag.StandardTagKeys;
+import com.netflix.servo.tag.Tag;
+import com.netflix.servo.tag.Tags;
+
+public class DynamicExample implements Monitor {
+    protected MonitorConfig config;
+    private long metricValue = 0;
+    private long timestamp = -1;
+
+    public DynamicExample(String id) {
+        this.config = MonitorConfig.builder(id).withTag(DataSourceType.GAUGE).build();
+    }
+    public synchronized void setMetricValue(long metricValue) {
+        setMetricValue(metricValue, -1);
+    }
+
+    public synchronized void setMetricValue(long metricValue, long timestamp) {
+        this.metricValue = metricValue;
+        this.timestamp = timestamp;
+        if (timestamp != -1) {
+            Tag timestampTag = Tags.newTag(StandardTagKeys.TIMESTAMP.getKeyName(), String.valueOf(timestamp));
+            this.config = this.config.withAdditionalTag(timestampTag);
+        }
+    }
+
+    @Override
+    public Object getValue() {
+        return this.metricValue;
+    }
+
+    @Override
+    public MonitorConfig getConfig() {
+        return config;
+    }
+}

--- a/servo-core/src/main/java/com/netflix/servo/publish/JmxMetricPoller.java
+++ b/servo-core/src/main/java/com/netflix/servo/publish/JmxMetricPoller.java
@@ -24,23 +24,11 @@ import com.google.common.collect.Maps;
 import com.netflix.servo.Metric;
 import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.monitor.MonitorConfig;
-import com.netflix.servo.tag.BasicTag;
-import com.netflix.servo.tag.SortedTagList;
-import com.netflix.servo.tag.StandardTagKeys;
-import com.netflix.servo.tag.Tag;
-import com.netflix.servo.tag.TagList;
-import com.netflix.servo.tag.Tags;
+import com.netflix.servo.tag.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.management.Attribute;
-import javax.management.InstanceNotFoundException;
-import javax.management.JMException;
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanInfo;
-import javax.management.MBeanServerConnection;
-import javax.management.ObjectName;
-import javax.management.ReflectionException;
+import javax.management.*;
 import javax.management.openmbean.CompositeData;
 import java.io.IOException;
 import java.util.List;
@@ -123,9 +111,16 @@ public final class JmxMetricPoller implements MetricPoller {
             String name,
             TagList tags,
             Object value) {
-        long now = System.currentTimeMillis();
         Number num = asNumber(value);
         if (num != null) {
+            long now = 0;
+            Tag timestampTag = tags.getTag(StandardTagKeys.TIMESTAMP.getKeyName());
+            if (timestampTag != null) {
+                now = Long.decode(timestampTag.getValue());
+            } else {
+                now = System.currentTimeMillis();
+            }
+
             TagList newTags = counters.matches(MonitorConfig.builder(name).withTags(tags).build())
                 ? SortedTagList.builder().withTags(tags).withTag(DataSourceType.COUNTER).build()
                 : SortedTagList.builder().withTags(tags).withTag(DataSourceType.GAUGE).build();

--- a/servo-core/src/main/java/com/netflix/servo/tag/StandardTagKeys.java
+++ b/servo-core/src/main/java/com/netflix/servo/tag/StandardTagKeys.java
@@ -27,7 +27,9 @@ public enum StandardTagKeys {
     CLASS_NAME("ClassName"),
 
     /** Monitor id if one is provided via the annotation. */
-    MONITOR_ID("MonitorId");
+    MONITOR_ID("MonitorId"),
+
+    TIMESTAMP("Timestamp");
 
     private String keyName;
 


### PR DESCRIPTION
I'm using servo in a setup where I need to be able to set the timestamp on metrics rather than using the current time (the metrics are collected in one process and periodically sent as a batch to the process running servo).
