### PR TITLE
Allow User defined AWSCloudWatch

### DIFF
--- a/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
+++ b/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 


### PR DESCRIPTION
A user may want to set some properties on cloudwatch
client like endpoint, region etc.

Log error with metrics that were failed to push
to cloudwatch
