### PR TITLE
Add record feature to DynamicTimer

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/monitor/DynamicTimer.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/DynamicTimer.java
@@ -123,6 +123,13 @@ public class DynamicTimer implements CompositeMonitor<Long> {
     }
 
     /**
+     * Record result to the dynamic timer indicated by the provided config.
+     */
+    public static void record(MonitorConfig config, long duration, TimeUnit unit){
+        INSTANCE.get(config, unit).record(duration);
+    }
+
+    /**
      * Returns a stopwatch that has been started and will automatically
      * record its result to the dynamic timer specified by the given name, and sequence of (key,
      * value) pairs. The timer uses a TimeUnit of milliseconds.


### PR DESCRIPTION
Was adding some DynamicTimers to a library and noticed DynamicTimer didn't have a "record".
