### PR TITLE
allow estimate of polling interval for the first reset

### DIFF
--- a/servo-core/src/test/java/com/netflix/servo/monitor/ResettableCounterTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/ResettableCounterTest.java
@@ -27,6 +27,10 @@ public class ResettableCounterTest extends AbstractMonitorTest<ResettableCounter
         return new ResettableCounter(MonitorConfig.builder(name).build());
     }
 
+    public ResettableCounter newInstance(String name, long interval) {
+        return new ResettableCounter(MonitorConfig.builder(name).build(), interval);
+    }
+
     @Test
     public void testHasGaugeTag() throws Exception {
         Tag type = newInstance("foo").getConfig().getTags().getTag("type");
@@ -65,6 +69,24 @@ public class ResettableCounterTest extends AbstractMonitorTest<ResettableCounter
         c.increment(1000000);
         rate = c.getAndResetValue().doubleValue();
         assertTrue(rate <= 2.001e7 && rate > 5e6);
+        assertEquals(c.getValue().longValue(), 0L);
+    }
+
+    @Test
+    public void testGetAndResetValueWithEstimate() throws Exception {
+        ResettableCounter c = newInstance("foo", 60000L);
+        assertEquals(c.getValue().longValue(), 0L);
+
+        // Check basic rate, if sleep exactly 50ms rate since the reset would be 20.0
+        c.increment();
+        Thread.sleep(50);
+        double rate = c.getValue().doubleValue();
+        assertTrue(rate <= 0.2 && rate > 0.0);
+
+        // Should be around 10m, allow 
+        c.increment(1000000);
+        rate = c.getAndResetValue().doubleValue();
+        assertTrue(rate <= 20.0e3 && rate > 10.0e3);
         assertEquals(c.getValue().longValue(), 0L);
     }
 


### PR DESCRIPTION
In use-cases where a counter can be created dynamically in the middle of a polling-interval, the time delta should be the time since the last poll as the change in count was essentially 0 from that time to the first increment and therefore the creation of the counter. Otherwise the first interval will have a higher rate simply because it was created later in the interval. This change allows the resettable counter to be created with an estimated polling interval used only until the first reset call on the counter.
