### PR TITLE
add helper method for getting the raw count

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/monitor/ResettableCounter.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/ResettableCounter.java
@@ -86,6 +86,11 @@ public class ResettableCounter extends AbstractMonitor<Number>
         return computeRate(now, lastReset, currentCount);
     }
 
+    /** Returns the raw count instead of the rate. This can be useful for unit tests. */
+    public long getCount() {
+        return count.get();
+    }
+
     /** Returns the rate per second since the last reset. */
     private double computeRate(long now, long lastReset, long currentCount) {
         final double delta = ((lastReset >= 0) ? (now - lastReset) : estPollingInterval) / 1000.0;

--- a/servo-core/src/test/java/com/netflix/servo/monitor/ResettableCounterTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/ResettableCounterTest.java
@@ -44,12 +44,14 @@ public class ResettableCounterTest extends AbstractMonitorTest<ResettableCounter
 
         // Check basic rate, if sleep exactly 50ms rate since the reset would be 20.0
         c.increment();
+        assertEquals(c.getCount(), 1L);
         Thread.sleep(50);
         double rate = c.getValue().doubleValue();
         assertTrue(rate <= 20.0 && rate > 0.0);
 
         // Should be around 10m, allow 
         c.increment(1000000);
+        assertEquals(c.getCount(), 1000001L);
         rate = c.getValue().doubleValue();
         assertTrue(rate <= 2.001e7 && rate > 5e6);
     }
@@ -67,7 +69,9 @@ public class ResettableCounterTest extends AbstractMonitorTest<ResettableCounter
 
         // Should be around 10m, allow 
         c.increment(1000000);
+        assertEquals(c.getCount(), 1000001L);
         rate = c.getAndResetValue().doubleValue();
+        assertEquals(c.getCount(), 0L);
         assertTrue(rate <= 2.001e7 && rate > 5e6);
         assertEquals(c.getValue().longValue(), 0L);
     }


### PR DESCRIPTION
Adding getCount helper for ResettableCounter so it is easier to unit test without worrying about the time component.
