### PR TITLE
cleanup checkstyle warnings

### DIFF
--- a/codequality/checkstyle_test.xml
+++ b/codequality/checkstyle_test.xml
@@ -1,73 +1,17 @@
 <?xml version="1.0"?>
-<!--
-  #%L
-  servo
-  %%
-  Copyright (C) 2011 - 2012 Netflix
-  %%
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-  
-       http://www.apache.org/licenses/LICENSE-2.0
-  
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  #L%
-  -->
-
 <!DOCTYPE module PUBLIC
-          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
-
-<!--
-
-  This file is based off the sun_checks.xml config that comes with checkstyle.
-  Minor modifications made, mostly to disable certain checks that are too
-  noisy.
-  
-  ===========================================================================
-
-  Checkstyle configuration that checks the sun coding conventions from:
-
-    - the Java Language Specification at
-      http://java.sun.com/docs/books/jls/second_edition/html/index.html
-
-    - the Sun Code Conventions at http://java.sun.com/docs/codeconv/
-
-    - the Javadoc guidelines at
-      http://java.sun.com/j2se/javadoc/writingdoccomments/index.html
-
-    - the JDK Api documentation http://java.sun.com/j2se/docs/api/index.html
-
-    - some best practices
-
-  Checkstyle is very configurable. Be sure to read the documentation at
-  http://checkstyle.sf.net (or in your downloaded distribution).
-
-  Most Checks are configurable, be sure to consult the documentation.
-
-  To completely disable a check, just comment it out or delete it from the file.
-
-  Finally, it is worth reading the documentation.
-
--->
+    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
-    <!--
-        If you set the basedir property below, then all reported file
-        names will be relative to the specified directory. See
-        http://checkstyle.sourceforge.net/5.x/config.html#Checker
-
-        <property name="basedir" value="${basedir}"/>
-    -->
 
     <!-- Checks that a package-info.java file exists for each package.     -->
     <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage -->
-    <module name="JavadocPackage"/>
+    <!--
+    <module name="JavadocPackage">
+      <property name="allowLegacy" value="true"/>
+    </module>
+    -->
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
@@ -76,42 +20,47 @@
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
     <module name="Translation"/>
-    
+
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="FileLength"/>
-    
+
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
     <module name="FileTabCharacter"/>
 
     <!-- Miscellaneous other checks.                   -->
     <!-- See http://checkstyle.sf.net/config_misc.html -->
-    <!-- Disabled because automatic license headers have some lines with
-         spaces at the end.
     <module name="RegexpSingleline">
        <property name="format" value="\s+$"/>
        <property name="minimum" value="0"/>
        <property name="maximum" value="0"/>
        <property name="message" value="Line has trailing spaces."/>
-    </module>-->
+       <property name="severity" value="info"/>
+    </module>
 
     <module name="TreeWalker">
 
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
-        <module name="JavadocMethod">
-            <property name="scope" value="public"/>
-            <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
-            <property name="allowMissingReturnTag" value="true"/>
+        <!--<module name="JavadocMethod">
+          <property name="scope" value="public"/>
+          <property name="allowMissingParamTags" value="true"/>
+          <property name="allowMissingThrowsTags" value="true"/>
+          <property name="allowMissingReturnTag" value="true"/>
+          <property name="allowThrowsTagsForSubclasses" value="true"/>
+          <property name="allowUndeclaredRTE" value="true"/>
+          <property name="allowMissingPropertyJavadoc" value="true"/>
         </module>
-        <module name="JavadocType"/>
+        <module name="JavadocType">
+          <property name="scope" value="package"/>
+        </module>
         <module name="JavadocVariable">
-            <property name="scope" value="public"/>
+          <property name="scope" value="package"/>
         </module>
-        <module name="JavadocStyle"/>
-
+        <module name="JavadocStyle">
+          <property name="checkEmptyJavadoc" value="true"/>
+        </module>-->
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->
@@ -125,28 +74,11 @@
         <module name="StaticVariableName"/>
         <module name="TypeName"/>
 
-
-        <!-- Checks for Headers                                -->
-        <!-- See http://checkstyle.sf.net/config_header.html   -->
-        <!-- <module name="Header">                            -->
-            <!-- The follow property value demonstrates the ability     -->
-            <!-- to have access to ANT properties. In this case it uses -->
-            <!-- the ${basedir} property to allow Checkstyle to be run  -->
-            <!-- from any directory within a project. See property      -->
-            <!-- expansion,                                             -->
-            <!-- http://checkstyle.sf.net/config.html#properties        -->
-            <!-- <property                                              -->
-            <!--     name="headerFile"                                  -->
-            <!--     value="${basedir}/java.header"/>                   -->
-        <!-- </module> -->
-
-        <!-- Following interprets the header file as regular expressions. -->
-        <!-- <module name="RegexpHeader"/>                                -->
-
-
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->
-        <module name="AvoidStarImport"/>
+        <module name="AvoidStarImport">
+          <property name="allowStaticMemberImports" value="true"/>
+        </module>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
@@ -154,7 +86,13 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength"/>
+        <module name="LineLength">
+          <!-- what is a good max value? -->
+          <property name="max" value="100"/>
+          <!-- ignore lines like "$File: //depot/... $" -->
+          <property name="ignorePattern" value="\$File.*\$"/>
+          <property name="severity" value="info"/>
+        </module>
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
 
@@ -169,9 +107,8 @@
         <module name="OperatorWrap"/>
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
-        <!--<module name="WhitespaceAfter"/>-->
+        <module name="WhitespaceAfter"/>
         <module name="WhitespaceAround"/>
-
 
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->
@@ -182,7 +119,9 @@
         <!-- Checks for blocks. You know, those {}'s         -->
         <!-- See http://checkstyle.sf.net/config_blocks.html -->
         <module name="AvoidNestedBlocks"/>
-        <module name="EmptyBlock"/>
+        <module name="EmptyBlock">
+          <property name="option" value="text"/>
+        </module>
         <module name="LeftCurly"/>
         <module name="NeedBraces"/>
         <module name="RightCurly"/>
@@ -191,37 +130,63 @@
         <!-- Checks for common coding problems               -->
         <!-- See http://checkstyle.sf.net/config_coding.html -->
         <!-- <module name="AvoidInlineConditionals"/> -->
-        <module name="DoubleCheckedLocking"/>    <!-- MY FAVOURITE -->
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="HiddenField">
-             <property name="ignoreConstructorParameter" value="true"/>
+          <property name="ignoreConstructorParameter" value="true"/>
+          <property name="ignoreSetter" value="true"/>
+          <property name="severity" value="warning"/>
         </module>
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
-        <module name="MagicNumber"/>
+        <!-- <module name="MagicNumber">
+          <property name="severity" value="warning"/>
+        </module> -->
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows"/>
+        <!-- Problem with finding exception types... -->
+        <module name="RedundantThrows">
+          <property name="allowUnchecked" value="true"/>
+          <property name="suppressLoadErrors" value="true"/>
+          <property name="severity" value="info"/>
+        </module>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
-        <module name="DesignForExtension"/>
+        <!-- <module name="DesignForExtension"/> -->
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>
-        <module name="VisibilityModifier"/>
+        <module name="VisibilityModifier">
+          <property name="protectedAllowed" value="true"/>
+        </module>
 
 
         <!-- Miscellaneous other checks.                   -->
         <!-- See http://checkstyle.sf.net/config_misc.html -->
         <module name="ArrayTypeStyle"/>
         <!-- <module name="FinalParameters"/> -->
-        <module name="TodoComment"/>
+        <module name="TodoComment">
+          <property name="format" value="TODO"/>
+          <property name="severity" value="info"/>
+        </module>
         <module name="UpperEll"/>
+
+        <module name="FileContentsHolder"/> <!-- Required by comment suppression filters -->
 
     </module>
 
+    <!-- Enable suppression comments -->
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE IGNORE\s+(\S+)"/>
+      <property name="onCommentFormat" value="CHECKSTYLE END IGNORE\s+(\S+)"/>
+      <property name="checkFormat" value="$1"/>
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+      <!-- Syntax is "SUPPRESS CHECKSTYLE name" -->
+      <property name="commentFormat" value="SUPPRESS CHECKSTYLE (\w+)"/>
+      <property name="checkFormat" value="$1"/>
+      <property name="influenceFormat" value="1"/>
+    </module>
 </module>
-

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -5,6 +5,9 @@ checkstyle {
     ignoreFailures = true 
     configFile = rootProject.file('codequality/checkstyle.xml')
 }
+checkstyleTest {
+    configFile = rootProject.file('codequality/checkstyle_test.xml')
+}
 
 // FindBugs
 apply plugin: 'findbugs'

--- a/servo-graphite/src/test/java/com/netflix/servo/publish/graphite/BasicGraphiteNamingConventionTest.java
+++ b/servo-graphite/src/test/java/com/netflix/servo/publish/graphite/BasicGraphiteNamingConventionTest.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertEquals;
 public class BasicGraphiteNamingConventionTest {
 
     @Test
-    public void testJmxNaming() throws Exception{
+    public void testJmxNaming() throws Exception {
         Metric m = getOSMetric("AvailableProcessors");
 
         GraphiteNamingConvention convention = new BasicGraphiteNamingConvention();
@@ -44,7 +44,7 @@ public class BasicGraphiteNamingConventionTest {
     }
 
     @Test
-    public void testMetricNaming() throws Exception{
+    public void testMetricNaming() throws Exception {
         Metric m = new Metric("simpleMonitor", SortedTagList.EMPTY, 0, 1000.0);
 
         GraphiteNamingConvention convention = new BasicGraphiteNamingConvention();
@@ -53,13 +53,14 @@ public class BasicGraphiteNamingConventionTest {
         assertEquals(name, "simpleMonitor");
     }
 
-    public static Metric getOSMetric(String name)  throws Exception{
+    public static Metric getOSMetric(String name)  throws Exception {
         MetricPoller poller = new JmxMetricPoller(
                 new LocalJmxConnector(),
                 new ObjectName("java.lang:type=OperatingSystem"),
                 MATCH_NONE);
 
-        List<Metric> metrics = poller.poll(new RegexMetricFilter(null, Pattern.compile(name), false, false));
+        RegexMetricFilter filter = new RegexMetricFilter(null, Pattern.compile(name), false, false);
+        List<Metric> metrics = poller.poll(filter);
         assertEquals(metrics.size(), 1);
         return metrics.get(0);
     }

--- a/servo-graphite/src/test/java/com/netflix/servo/publish/graphite/GraphiteMetricObserverTest.java
+++ b/servo-graphite/src/test/java/com/netflix/servo/publish/graphite/GraphiteMetricObserverTest.java
@@ -33,30 +33,28 @@ public class GraphiteMetricObserverTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadAddress1() throws Exception {
-        new GraphiteMetricObserver( "serverA", getLocalHostIp() );
+        new GraphiteMetricObserver("serverA", getLocalHostIp());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testBadAddress2() throws Exception
-    {
-        new GraphiteMetricObserver( "serverA", "http://google.com" );
+    public void testBadAddress2() throws Exception {
+        new GraphiteMetricObserver("serverA", "http://google.com");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBadAddress3() throws Exception {
-        new GraphiteMetricObserver( "serverA", "socket://" + getLocalHostIp() + ":808" );
+        new GraphiteMetricObserver("serverA", "socket://" + getLocalHostIp() + ":808");
     }
 
     @Test
-    public void testSuccessfulSend() throws Exception
-    {
-        SocketReceiverTester receiver = new SocketReceiverTester( 8082 );
+    public void testSuccessfulSend() throws Exception {
+        SocketReceiverTester receiver = new SocketReceiverTester(8082);
         receiver.start();
 
-        GraphiteMetricObserver gw = new GraphiteMetricObserver( "serverA", getLocalHostIp() + ":8082" );
+        String host = getLocalHostIp() + ":8082";
+        GraphiteMetricObserver gw = new GraphiteMetricObserver("serverA", host);
 
-        try
-        {
+        try {
             List<Metric> metrics = new ArrayList<Metric>();
             metrics.add(BasicGraphiteNamingConventionTest.getOSMetric("AvailableProcessors"));
 
@@ -64,14 +62,13 @@ public class GraphiteMetricObserverTest {
 
             receiver.waitForConnected();
 
-            String[] lines = receiver.waitForLines( 1 );
-            assertEquals( 1, lines.length );
+            String[] lines = receiver.waitForLines(1);
+            assertEquals(1, lines.length);
 
-            assertEquals(lines[0].indexOf("serverA.java.lang.OperatingSystem.AvailableProcessors"), 0);
+            int found = lines[0].indexOf("serverA.java.lang.OperatingSystem.AvailableProcessors");
+            assertEquals(found, 0);
 
-        }
-        finally
-        {
+        } finally {
             receiver.stop();
             gw.stop();
         }

--- a/servo-graphite/src/test/java/com/netflix/servo/publish/graphite/SocketReceiverTester.java
+++ b/servo-graphite/src/test/java/com/netflix/servo/publish/graphite/SocketReceiverTester.java
@@ -24,8 +24,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Arrays;
 
-public class SocketReceiverTester implements Runnable
-{
+public class SocketReceiverTester implements Runnable {
     private final ServerSocket acceptor;
     private Socket s;
 
@@ -35,36 +34,34 @@ public class SocketReceiverTester implements Runnable
     private volatile int linesRead = 0;
     private volatile int linesWritten = 0;
 
-    public SocketReceiverTester( int port ) throws IOException
-    {
+    public SocketReceiverTester(int port) throws IOException {
         ServerSocketFactory socketFactory = ServerSocketFactory.getDefault();
         acceptor = socketFactory.createServerSocket();
-        acceptor.setReuseAddress( true );
-        acceptor.bind( new InetSocketAddress( port ) );
+        acceptor.setReuseAddress(true);
+        acceptor.bind(new InetSocketAddress(port));
     }
 
     @Override
     public void run() {
-        while ( running ) {
+        while (running) {
             try {
                 s = acceptor.accept();
-                synchronized ( this ) {
+                synchronized (this) {
                     connected = true;
                     notify();
                 }
-                BufferedReader stream = new BufferedReader( new InputStreamReader( s.getInputStream(), "UTF-8" ) );
+                BufferedReader stream = new BufferedReader(
+                    new InputStreamReader(s.getInputStream(), "UTF-8"));
 
-                while ( running ) {
+                while (running) {
                     String line = stream.readLine();
-                    synchronized ( this )
-                    {
+                    synchronized (this) {
                         lines[linesWritten++ % lines.length] = line;
                         notify();
                     }
                 }
-            }
-            catch ( IOException e ) {
-                synchronized ( this ) {
+            } catch (IOException e) {
+                synchronized (this) {
                     connected = false;
                     linesWritten = 0;
                     linesRead = 0;
@@ -74,16 +71,16 @@ public class SocketReceiverTester implements Runnable
         }
     }
 
-    Thread thread;
+    private Thread thread;
 
     public void start() {
-        thread = new Thread( this );
+        thread = new Thread(this);
         thread.start();
     }
 
     public void stop() throws Exception {
         running = false;
-        if ( s != null ) {
+        if (s != null) {
             s.close();
         }
         acceptor.close();
@@ -91,16 +88,17 @@ public class SocketReceiverTester implements Runnable
         thread.join();
     }
 
-    public String[] waitForLines( int waitingFor ) throws Exception {
+    public String[] waitForLines(int waitingFor) throws Exception {
         long start = System.currentTimeMillis();
-        synchronized ( this ) {
-            while ( linesWritten < linesRead + waitingFor ) {
-                if ( !connected )
-                    throw new IllegalArgumentException( "Not connected!" );
-                if ( System.currentTimeMillis() - start > 1000 ) {
-                    throw new InterruptedException( "Timed out!" );
+        synchronized (this) {
+            while (linesWritten < linesRead + waitingFor) {
+                if (!connected) {
+                    throw new IllegalArgumentException("Not connected!");
                 }
-                wait( 100 );
+                if (System.currentTimeMillis() - start > 1000) {
+                    throw new InterruptedException("Timed out!");
+                }
+                wait(100);
             }
             return Arrays.copyOfRange(lines, linesRead, linesRead + waitingFor);
         }
@@ -108,12 +106,12 @@ public class SocketReceiverTester implements Runnable
 
     public void waitForConnected() throws Exception {
         long start = System.currentTimeMillis();
-        synchronized ( this ) {
-            while ( !connected ) {
-                if ( System.currentTimeMillis() - start > 1000 ) {
-                    throw new InterruptedException( "Timed out!" );
+        synchronized (this) {
+            while (!connected) {
+                if (System.currentTimeMillis() - start > 1000) {
+                    throw new InterruptedException("Timed out!");
                 }
-                wait( 100 );
+                wait(100);
             }
         }
 


### PR DESCRIPTION
This change:
1. Separate checkstyle config for tests that is a bit more relaxed. In particular, no javadoc requirements or magic number check.
2. Removed unused nflx_checks.xml file.
3. Cleanup some misc formatting issues that were causing warnings.

Checkstyle now runs cleanly:

$ ./gradlew checkstyleTest
:servo-core:compileJava UP-TO-DATE
:servo-core:processResources UP-TO-DATE
:servo-core:classes UP-TO-DATE
:servo-core:jar UP-TO-DATE
:servo-aws:compileJava UP-TO-DATE
:servo-aws:processResources UP-TO-DATE
:servo-aws:classes UP-TO-DATE
:servo-aws:compileTestJava UP-TO-DATE
:servo-aws:processTestResources UP-TO-DATE
:servo-aws:testClasses UP-TO-DATE
:servo-aws:checkstyleTest UP-TO-DATE
:servo-core:compileTestJava UP-TO-DATE
:servo-core:processTestResources UP-TO-DATE
:servo-core:testClasses UP-TO-DATE
:servo-core:checkstyleTest UP-TO-DATE
:servo-graphite:compileJava UP-TO-DATE
:servo-graphite:processResources UP-TO-DATE
:servo-graphite:classes UP-TO-DATE
:servo-graphite:jar UP-TO-DATE
:servo-example:compileJava UP-TO-DATE
:servo-example:processResources UP-TO-DATE
:servo-example:classes UP-TO-DATE
:servo-example:compileTestJava UP-TO-DATE
:servo-example:processTestResources UP-TO-DATE
:servo-example:testClasses UP-TO-DATE
:servo-example:checkstyleTest UP-TO-DATE
:servo-graphite:compileTestJava UP-TO-DATE
:servo-graphite:processTestResources UP-TO-DATE
:servo-graphite:testClasses UP-TO-DATE
:servo-graphite:checkstyleTest UP-TO-DATE

BUILD SUCCESSFUL

Total time: 11.384 secs
