### PR TITLE
Add support for Eucalyptus endpoints

### DIFF
--- a/servo-aws/src/main/java/com/netflix/servo/aws/AwsPropertyKeys.java
+++ b/servo-aws/src/main/java/com/netflix/servo/aws/AwsPropertyKeys.java
@@ -21,4 +21,6 @@ package com.netflix.servo.aws;
 public class AwsPropertyKeys {
 
     public static final String awsCredentialsFile = "com.netflix.servo.aws.credentialsFile";
+    public static final String awsAutoScalingEndpoint = "com.netflix.servo.aws.endpoint.autoscaling";
+    public static final String awsCloudWatchEndpoint = "com.netflix.servo.aws.endpoint.cloudwatch";
 }

--- a/servo-aws/src/main/java/com/netflix/servo/aws/AwsServiceClients.java
+++ b/servo-aws/src/main/java/com/netflix/servo/aws/AwsServiceClients.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo.aws;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
+import com.amazonaws.services.autoscaling.AmazonAutoScalingClient;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+
+/**
+ * Static helpers for constructing configured AWS service clients
+ */
+public class AwsServiceClients {
+
+  /**
+   * Get a CloudWatch client whose endpoint is configured based on properties
+   */
+  public static AmazonCloudWatch cloudWatch(AWSCredentialsProvider credentials ) {
+    AmazonCloudWatch client = new AmazonCloudWatchClient(credentials);
+    client.setEndpoint( System.getProperty( AwsPropertyKeys.awsCloudWatchEndpoint, "monitoring.amazonaws.com" ) );
+    return client;
+  }
+
+  /**
+   * Get an AutoScaling client whose endpoint is configured based on properties
+   */
+  public static AmazonAutoScaling autoScaling(AWSCredentials credentials) {
+    AmazonAutoScaling client = new AmazonAutoScalingClient(credentials);
+    client.setEndpoint( System.getProperty( AwsPropertyKeys.awsAutoScalingEndpoint, "autoscaling.amazonaws.com" ) );
+    return client;
+  }
+}

--- a/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
+++ b/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
@@ -29,6 +29,8 @@ import com.google.common.base.Preconditions;
 import com.netflix.servo.tag.Tag;
 import com.netflix.servo.tag.TagList;
 
+import com.netflix.servo.aws.AwsPropertyKeys;
+import com.netflix.servo.aws.AwsServiceClients;
 import com.netflix.servo.publish.BaseMetricObserver;
 import com.netflix.servo.Metric;
 
@@ -106,7 +108,7 @@ public class CloudWatchMetricObserver extends BaseMetricObserver {
      * @param provider Amazon credentials provider
      */
     public CloudWatchMetricObserver(String name, String namespace, AWSCredentialsProvider provider) {
-        this(name, namespace, new AmazonCloudWatchClient(provider));
+        this(name, namespace, AwsServiceClients.cloudWatch(provider));
     }
 
     /**

--- a/servo-aws/src/main/java/com/netflix/servo/tag/aws/AwsInjectableTag.java
+++ b/servo-aws/src/main/java/com/netflix/servo/tag/aws/AwsInjectableTag.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.autoscaling.model.DescribeAutoScalingInstancesRequ
 import com.google.common.io.Closeables;
 
 import com.netflix.servo.aws.AwsPropertyKeys;
+import com.netflix.servo.aws.AwsServiceClients;
 import com.netflix.servo.tag.Tag;
 
 import com.netflix.servo.aws.constants.Dimensions;
@@ -99,7 +100,7 @@ public enum AwsInjectableTag implements Tag {
                 credentials = new DefaultAWSCredentialsProviderChain().getCredentials();
             }
 
-            AmazonAutoScaling autoScalingClient = new AmazonAutoScalingClient(credentials);
+            AmazonAutoScaling autoScalingClient = AwsServiceClients.autoScaling(credentials);
 
             return autoScalingClient.describeAutoScalingInstances(
                     new DescribeAutoScalingInstancesRequest().withInstanceIds(getInstanceId()))


### PR DESCRIPTION
- Add facade for constructing AWS service clients w/ configured endpoints.
- Add properties for setting AutoScaling and CloudWatch endpoints.
  com.netflix.servo.aws.endpoint.cloudwatch
  com.netflix.servo.aws.endpoint.autoscaling
- Construct clients using facade in CloudWatchMetricObserver and
  AwsInjectableTag.
