### PR TITLE
Allow the mapping from monitor to JMX ObjectName to be configurable via ...

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/annotations/DataSourceType.java
+++ b/servo-core/src/main/java/com/netflix/servo/annotations/DataSourceType.java
@@ -49,8 +49,11 @@ public enum DataSourceType implements Tag {
      */
     INFORMATIONAL;
 
-    /** Key name used for the data source type tag. */
-    public static final String KEY = "type";
+    /** 
+     *  Key name used for the data source type tag, configurable via 
+     *  servo.datasourcetype.key system property.
+     */
+    public static final String KEY = System.getProperty("servo.datasourcetype.key", "type");
 
     /** {@inheritDoc} */
     public String getKey() {

--- a/servo-core/src/main/java/com/netflix/servo/jmx/DefaultObjectNameMapper.java
+++ b/servo-core/src/main/java/com/netflix/servo/jmx/DefaultObjectNameMapper.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo.jmx;
+
+import javax.management.ObjectName;
+
+import com.netflix.servo.monitor.Monitor;
+
+/**
+ * The default {@link ObjectNameMapper} implementation that
+ * is used by the {@link JmxMonitorRegistry}. This implementation
+ * simply appends the monitor's name followed by the tags for the monitor.
+ *
+ */
+class DefaultObjectNameMapper implements ObjectNameMapper {
+
+    @Override
+    public ObjectName createObjectName(String domain, Monitor<?> monitor) {
+        ObjectNameBuilder objNameBuilder = ObjectNameBuilder.forDomain(domain);
+        objNameBuilder.addProperty("name", monitor.getConfig().getName());
+        objNameBuilder.addProperties(monitor.getConfig().getTags());
+        return objNameBuilder.build();
+    }
+
+}

--- a/servo-core/src/main/java/com/netflix/servo/jmx/ObjectNameBuilder.java
+++ b/servo-core/src/main/java/com/netflix/servo/jmx/ObjectNameBuilder.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo.jmx;
+
+import java.util.regex.Pattern;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Throwables;
+import com.netflix.servo.tag.Tag;
+import com.netflix.servo.tag.TagList;
+
+/**
+ * A helper class that assists in building
+ * {@link ObjectName}s given monitor {@link Tag}s
+ * or {@link TagList}. The builder also sanitizes
+ * all values to avoid invalid input. Any characters that are
+ * not alphanumeric, a period, or hypen are considered invalid
+ * and are remapped to underscores.
+ *
+ */
+final class ObjectNameBuilder {
+
+    private static final Pattern INVALID_CHARS = Pattern.compile("[^a-zA-Z0-9_\\-\\.]");
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectNameBuilder.class);
+
+    /**
+     * Sanitizes a value by replacing any character that is not alphanumeric,
+     * a period, or hyphen with an underscore.
+     * @param value  the value to sanitize
+     * @return       the sanitized value
+     */
+    public static String sanitizeValue(String value) {
+        return INVALID_CHARS.matcher(value).replaceAll("_");
+    }
+
+    /**
+     * Creates an {@link ObjectNameBuilder} given the JMX domain.
+     * @param domain the JMX domain
+     * @return The ObjectNameBuilder
+     */
+    public static ObjectNameBuilder forDomain(String domain) {
+        return new ObjectNameBuilder(domain);
+    }
+
+    private final StringBuilder nameStrBuilder;
+
+    private ObjectNameBuilder(String domain) {
+        nameStrBuilder = new StringBuilder(sanitizeValue(domain));
+        nameStrBuilder.append(":");
+    }
+
+    /**
+     * Adds the {@link TagList} as {@link ObjectName} properties.
+     * @param tagList the tag list to add
+     * @return This builder
+     */
+    public ObjectNameBuilder addProperties(TagList tagList) {
+        for (Tag tag : tagList) {
+            addProperty(tag);
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds the {@link Tag} as a {@link ObjectName} property.
+     * @param tag the tag to add
+     * @return This builder
+     */
+    public ObjectNameBuilder addProperty(Tag tag) {
+        return addProperty(tag.getKey(), tag.getValue());
+    }
+
+    /**
+     * Adds the key/value as a {@link ObjectName} property.
+     * @param key    the key to add
+     * @param value  the value to add
+     * @return This builder
+     */
+    public ObjectNameBuilder addProperty(String key, String value) {
+        nameStrBuilder.append(sanitizeValue(key))
+                      .append('=')
+                      .append(sanitizeValue(value)).append(",");
+        return this;
+    }
+
+    /**
+     * Builds the {@link ObjectName} given the configuration.
+     * @return The created ObjectName
+     */
+    public ObjectName build() {
+        final String name = nameStrBuilder.substring(0, nameStrBuilder.length() - 1);
+        try {
+            return new ObjectName(name);
+        } catch (MalformedObjectNameException e) {
+            LOG.warn("Invalid ObjectName provided: " + name);
+            throw Throwables.propagate(e);
+        }
+    }
+
+}

--- a/servo-core/src/main/java/com/netflix/servo/jmx/ObjectNameMapper.java
+++ b/servo-core/src/main/java/com/netflix/servo/jmx/ObjectNameMapper.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo.jmx;
+
+import javax.management.ObjectName;
+
+import com.netflix.servo.monitor.Monitor;
+
+/**
+ * Allows for different implementations when mapping a
+ * monitor to a JMX {@link ObjectName}. The mapper can be
+ * can be specified when using the {@link JmxMonitorRegistry}.
+ * This interface also has a reference to the default mapping implementation.
+ * Note that an {@link ObjectName}'s properties are meant to be unordered,
+ * however, some tools such as VisualVM use the order to build a hierarchy
+ * view where the default implementation may not be desirable.
+ */
+public interface ObjectNameMapper {
+
+    /**
+     * The default mapping implementation. This implementation simply
+     * appends the monitor's name followed by all the tags as properties
+     * of the {@link ObjectName}. The mapper remaps any characters that are
+     * not alphanumeric, a period, or hypen to an underscore.
+     */
+    ObjectNameMapper DEFAULT = new DefaultObjectNameMapper();
+
+    /**
+     * Given the domain and monitor generates an {@link ObjectName} to use.
+     * @param domain  the JMX domain
+     * @param monitor the monitor
+     * @return The created ObjectName
+     */
+    ObjectName createObjectName(String domain, Monitor<?> monitor);
+
+}

--- a/servo-core/src/main/java/com/netflix/servo/jmx/OrderedObjectNameMapper.java
+++ b/servo-core/src/main/java/com/netflix/servo/jmx/OrderedObjectNameMapper.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo.jmx;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.management.ObjectName;
+
+import com.netflix.servo.monitor.Monitor;
+
+/**
+ * An {@link ObjectNameMapper} that allows the order of
+ * tags to be specified when constructing the {@link ObjectName}.
+ * The mapper will map the known ordered tag keys and then optionally
+ * append the remaining tags. While an {@link ObjectName}'s properties
+ * are meant to be unordered some visual tools such as VisualVM use the
+ * given order to build a hierarchy. This ordering allows that hierarchy
+ * to be manipulated.
+ * <p>
+ * It is recommended to always append the remaining tags to avoid collisions
+ * in the generated {@link ObjectName}. The mapper remaps any characters that
+ * are not alphanumeric, a period, or hypen to an underscore.
+ *
+ */
+public final class OrderedObjectNameMapper implements ObjectNameMapper {
+
+    private final List<String> keyOrder;
+    private final boolean appendRemaining;
+    private final boolean orderIncludesName;
+
+    /**
+     * Creates the mapper specifying the order of keys to use and whether
+     * non-explicitly mentioned tag keys should then be appended or not to
+     * the resulting {@link ObjectName}.
+     * @param appendRemaining  whether to append the remaining tags
+     * @param orderedKeys             the keys in order that should be used
+     */
+    public OrderedObjectNameMapper(boolean appendRemaining, String... orderedKeys) {
+        this(appendRemaining, Arrays.asList(orderedKeys));
+    }
+
+    /**
+     * Creates the mapper specifying the order of keys to use and whether
+     * non-explicitly mentioned tag keys should then be appended or not to
+     * the resulting {@link ObjectName}.
+     * @param appendRemaining  whether to append the remaining tags
+     * @param orderedKeys             the list of keys in the order that should be used
+     */
+    public OrderedObjectNameMapper(boolean appendRemaining, List<String> orderedKeys) {
+        this.keyOrder = new ArrayList<String>(orderedKeys);
+        this.appendRemaining = appendRemaining;
+        this.orderIncludesName = keyOrder.contains("name");
+    }
+
+    @Override
+    public ObjectName createObjectName(String domain, Monitor<?> monitor) {
+        ObjectNameBuilder objBuilder = ObjectNameBuilder.forDomain(domain);
+        Map<String, String> tags = new TreeMap<String, String>(
+                monitor.getConfig().getTags().asMap());
+        // For the known ordered keys, try to add them if they're present in the monitor's tags
+        for (String knownKey : keyOrder) {
+            // Special case for name as it isn't a tag
+            if (knownKey.equals("name")) {
+                addName(objBuilder, monitor);
+            } else {
+                String value = tags.remove(knownKey);
+                if (value != null) {
+                    objBuilder.addProperty(knownKey, value);
+                }
+            }
+        }
+
+        // If appending, then add the name (if not already added) and remaining tags
+        if (appendRemaining) {
+            if (!orderIncludesName) {
+                addName(objBuilder, monitor);
+            }
+
+            for (Map.Entry<String, String> additionalTag : tags.entrySet()) {
+                objBuilder.addProperty(additionalTag.getKey(), additionalTag.getValue());
+            }
+        }
+
+        return objBuilder.build();
+    }
+
+    private void addName(ObjectNameBuilder builder, Monitor<?> monitor) {
+        builder.addProperty("name", monitor.getConfig().getName());
+    }
+
+}

--- a/servo-core/src/test/java/com/netflix/servo/jmx/DefaultObjectNameMapperTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/jmx/DefaultObjectNameMapperTest.java
@@ -1,0 +1,44 @@
+package com.netflix.servo.jmx;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.testng.annotations.Test;
+
+import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.monitor.BasicCounter;
+import com.netflix.servo.monitor.MonitorConfig;
+
+import static org.testng.Assert.*;
+
+public class DefaultObjectNameMapperTest {
+
+    private static final ObjectNameMapper DEFAULT_MAPPER = new DefaultObjectNameMapper();
+    private static final String TEST_DOMAIN = "testDomain";
+
+    @Test
+    public void testStandardMapping() {
+        MonitorConfig config = MonitorConfig.builder("testName").withTag("foo", "bar").build();
+        ObjectName name = DEFAULT_MAPPER.createObjectName(TEST_DOMAIN, new BasicCounter(config));
+        assertEquals(name.getDomain(), TEST_DOMAIN);
+        assertEquals(name.getKeyPropertyListString(), 
+                String.format("name=testName,%s=COUNTER,foo=bar",
+                        DataSourceType.KEY));
+    }
+
+    @Test
+    public void testMultipleTags() throws MalformedObjectNameException {
+        BasicCounter counter = new BasicCounter(
+                               MonitorConfig.builder("testName")
+                                            .withTag("bbb", "foo")
+                                            .withTag("aaa", "bar")
+                                            .withTag("zzz", "test")
+                                            .build());
+        ObjectName name = DEFAULT_MAPPER.createObjectName(TEST_DOMAIN, counter);
+        assertEquals(name.getDomain(), TEST_DOMAIN);
+        assertEquals(name.getKeyPropertyListString(),
+                String.format("name=testName,aaa=bar,bbb=foo,zzz=test,%s=COUNTER",
+                        DataSourceType.KEY));
+    }
+
+}

--- a/servo-core/src/test/java/com/netflix/servo/jmx/ObjectNameBuilderTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/jmx/ObjectNameBuilderTest.java
@@ -1,0 +1,57 @@
+package com.netflix.servo.jmx;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.testng.annotations.Test;
+
+import com.netflix.servo.tag.BasicTag;
+import com.netflix.servo.tag.BasicTagList;
+
+import static org.testng.Assert.*;
+
+public class ObjectNameBuilderTest {
+
+    @Test
+    public void testInvalidCharactersSanitized() {
+        ObjectName name =
+                ObjectNameBuilder.forDomain("test*Domain&")
+                                 .addProperty("foo%", "$bar")
+                                 .build();
+        assertEquals(name.getDomain(), "test_Domain_");
+        assertEquals(name.getKeyPropertyListString(), "foo_=_bar");
+    }
+
+    @Test
+    public void testAddTagList() {
+        ObjectName name =
+                ObjectNameBuilder.forDomain("testDomain")
+                                 .addProperties(BasicTagList.of("foo", "bar", "test", "stuff"))
+                                 .build();
+        assertEquals(name.getDomain(), "testDomain");
+        assertEquals(name.getKeyPropertyListString(), "test=stuff,foo=bar");
+    }
+
+    @Test
+    public void testTagByTag() {
+        // Order will be in the order tags were added to the builder
+        ObjectName name =
+                ObjectNameBuilder.forDomain("testDomain")
+                                 .addProperty(new BasicTag("foo", "bar"))
+                                 .addProperty(new BasicTag("test", "stuff"))
+                                 .build();
+        assertEquals(name.getDomain(), "testDomain");
+        assertEquals(name.getKeyPropertyListString(), "foo=bar,test=stuff");
+    }
+
+    @Test
+    public void testBuildWithoutPropertyAdded() {
+        try {
+            ObjectNameBuilder.forDomain("testDomain").build();
+            fail("Should have thrown an exception without keys being added!");
+        } catch (RuntimeException expected) {
+            assertEquals(expected.getCause().getClass(), MalformedObjectNameException.class);
+        }
+    }
+
+}

--- a/servo-core/src/test/java/com/netflix/servo/jmx/OrderedObjectNameMapperTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/jmx/OrderedObjectNameMapperTest.java
@@ -1,0 +1,59 @@
+package com.netflix.servo.jmx;
+
+import javax.management.ObjectName;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.monitor.BasicCounter;
+import com.netflix.servo.monitor.Counter;
+import com.netflix.servo.monitor.MonitorConfig;
+
+import static org.testng.Assert.*;
+
+public class OrderedObjectNameMapperTest {
+
+    private static final String TEST_DOMAIN = "testDomain";
+    private static final Counter TEST_COUNTER =
+            new BasicCounter(
+                MonitorConfig.builder("testName")
+                .withTag("zzz", "zzzVal")
+                .withTag("foo", "bar")
+                .withTag("aaa", "aaaVal")
+                .build());
+
+    @Test
+    public void testOrderedTagsWithAppend() {
+        ObjectNameMapper mapper =
+                new OrderedObjectNameMapper(true, "name",
+                        DataSourceType.KEY, "foo", "notPresentKey");
+        ObjectName name = mapper.createObjectName(TEST_DOMAIN, TEST_COUNTER);
+        assertEquals(name.getDomain(), TEST_DOMAIN);
+        assertEquals(name.getKeyPropertyListString(),
+                String.format("name=testName,%s=COUNTER,foo=bar,aaa=aaaVal,zzz=zzzVal",
+                        DataSourceType.KEY));
+    }
+
+    @Test
+    public void testOrderedTagsWithoutAppend() {
+        ObjectNameMapper mapper = new OrderedObjectNameMapper(false,
+                Lists.newArrayList("name", DataSourceType.KEY, "foo", "notPresentKey"));
+        ObjectName name = mapper.createObjectName(TEST_DOMAIN, TEST_COUNTER);
+        assertEquals(name.getDomain(), TEST_DOMAIN);
+        assertEquals(name.getKeyPropertyListString(),
+                String.format("name=testName,%s=COUNTER,foo=bar",
+                        DataSourceType.KEY));
+    }
+
+    @Test
+    public void testOrderedTagsWithoutNameExplicitlyOrdered() {
+        ObjectNameMapper mapper = new OrderedObjectNameMapper(true, "foo", DataSourceType.KEY);
+        ObjectName name = mapper.createObjectName(TEST_DOMAIN, TEST_COUNTER);
+        assertEquals(name.getDomain(), TEST_DOMAIN);
+        assertEquals(name.getKeyPropertyListString(),
+                String.format("foo=bar,%s=COUNTER,name=testName,aaa=aaaVal,zzz=zzzVal",
+                        DataSourceType.KEY));
+    }
+
+}

--- a/servo-core/src/test/java/com/netflix/servo/monitor/BasicCounterTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/BasicCounterTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.tag.Tag;
 
 import org.testng.annotations.Test;
@@ -29,7 +30,7 @@ public class BasicCounterTest extends AbstractMonitorTest<BasicCounter> {
 
     @Test
     public void testHasCounterTag() throws Exception {
-        Tag type = newInstance("foo").getConfig().getTags().getTag("type");
+        Tag type = newInstance("foo").getConfig().getTags().getTag(DataSourceType.KEY);
         assertEquals(type.getValue(), "COUNTER");
     }
 

--- a/servo-core/src/test/java/com/netflix/servo/monitor/DoubleGaugeTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/DoubleGaugeTest.java
@@ -17,6 +17,8 @@ package com.netflix.servo.monitor;
 
 import org.testng.annotations.Test;
 
+import com.netflix.servo.annotations.DataSourceType;
+
 import static org.testng.Assert.assertEquals;
 
 public class DoubleGaugeTest extends AbstractMonitorTest<DoubleGauge> {
@@ -35,7 +37,7 @@ public class DoubleGaugeTest extends AbstractMonitorTest<DoubleGauge> {
     @Test
     public void testGetConfig() throws Exception {
         DoubleGauge gauge = newInstance("test");
-        MonitorConfig expectedConfig = MonitorConfig.builder("test").withTag("type", "GAUGE").build();
+        MonitorConfig expectedConfig = MonitorConfig.builder("test").withTag(DataSourceType.KEY, "GAUGE").build();
         assertEquals(gauge.getConfig(), expectedConfig);
     }
 }

--- a/servo-core/src/test/java/com/netflix/servo/monitor/DynamicCounterTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/DynamicCounterTest.java
@@ -16,6 +16,7 @@
 package com.netflix.servo.monitor;
 
 import com.google.common.collect.ImmutableList;
+import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.jsr166e.ConcurrentHashMapV8;
 import com.netflix.servo.tag.BasicTag;
 import com.netflix.servo.tag.BasicTagList;
@@ -64,7 +65,7 @@ public class DynamicCounterTest {
     public void testHasRightType() throws Exception {
         DynamicCounter.increment("test1", tagList);
         StepCounter c = getByName("test1");
-        Tag type = c.getConfig().getTags().getTag("type");
+        Tag type = c.getConfig().getTags().getTag(DataSourceType.KEY);
         assertEquals(type.getValue(), "GAUGE");
     }
 

--- a/servo-core/src/test/java/com/netflix/servo/monitor/LongGaugeTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/LongGaugeTest.java
@@ -17,6 +17,8 @@ package com.netflix.servo.monitor;
 
 import org.testng.annotations.Test;
 
+import com.netflix.servo.annotations.DataSourceType;
+
 import static org.testng.Assert.assertEquals;
 
 public class LongGaugeTest extends AbstractMonitorTest<LongGauge> {
@@ -43,7 +45,7 @@ public class LongGaugeTest extends AbstractMonitorTest<LongGauge> {
     @Test
     public void testGetConfig() throws Exception {
         LongGauge gauge = newInstance("test");
-        MonitorConfig expectedConfig = MonitorConfig.builder("test").withTag("type", "GAUGE").build();
+        MonitorConfig expectedConfig = MonitorConfig.builder("test").withTag(DataSourceType.KEY, "GAUGE").build();
         assertEquals(gauge.getConfig(), expectedConfig);
     }
 

--- a/servo-core/src/test/java/com/netflix/servo/monitor/PeakRateCounterTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/PeakRateCounterTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.tag.Tag;
 import com.netflix.servo.util.ManualClock;
 import org.testng.annotations.Test;
@@ -74,7 +75,7 @@ public class PeakRateCounterTest extends AbstractMonitorTest<PeakRateCounter> {
 
     @Test
     public void testHasRightType() throws Exception {
-        Tag type = newInstance("foo").getConfig().getTags().getTag("type");
+        Tag type = newInstance("foo").getConfig().getTags().getTag(DataSourceType.KEY);
         assertEquals(type.getValue(), "GAUGE");
     }
 

--- a/servo-core/src/test/java/com/netflix/servo/monitor/ResettableCounterTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/ResettableCounterTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.tag.Tag;
 import org.testng.annotations.Test;
 
@@ -29,7 +30,7 @@ public class ResettableCounterTest extends AbstractMonitorTest<ResettableCounter
 
     @Test
     public void testHasRightType() throws Exception {
-        Tag type = newInstance("foo").getConfig().getTags().getTag("type");
+        Tag type = newInstance("foo").getConfig().getTags().getTag(DataSourceType.KEY);
         assertEquals(type.getValue(), "GAUGE");
     }
 }

--- a/servo-core/src/test/java/com/netflix/servo/monitor/StepCounterTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/StepCounterTest.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.util.ManualClock;
 import org.testng.annotations.Test;
 
@@ -66,7 +67,7 @@ public class StepCounterTest {
 
     @Test
     public void testHasRightType() throws Exception {
-        assertEquals(newInstance("foo").getConfig().getTags().getValue("type"), "GAUGE");
+        assertEquals(newInstance("foo").getConfig().getTags().getValue(DataSourceType.KEY), "GAUGE");
     }
 
     @Test

--- a/servo-core/src/test/java/com/netflix/servo/publish/CounterToRateMetricTransformTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/publish/CounterToRateMetricTransformTest.java
@@ -59,7 +59,7 @@ public class CounterToRateMetricTransformTest {
     private Map<String, String> mkTypeMap(List<List<Metric>> updates) {
         Map<String, String> map = Maps.newHashMap();
         for (Metric m : updates.get(0)) {
-            map.put(m.getConfig().getName(), m.getConfig().getTags().getValue("type"));
+            map.put(m.getConfig().getName(), m.getConfig().getTags().getValue(DataSourceType.KEY));
         }
         return map;
     }

--- a/servo-graphite/src/main/java/com/netflix/servo/publish/graphite/BasicGraphiteNamingConvention.java
+++ b/servo-graphite/src/main/java/com/netflix/servo/publish/graphite/BasicGraphiteNamingConvention.java
@@ -16,6 +16,7 @@
 package com.netflix.servo.publish.graphite;
 
 import com.netflix.servo.Metric;
+import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.monitor.MonitorConfig;
 import com.netflix.servo.tag.Tag;
 import com.netflix.servo.tag.TagList;
@@ -42,7 +43,7 @@ public class BasicGraphiteNamingConvention implements GraphiteNamingConvention {
     }
 
     private String handleMetric(MonitorConfig config, TagList tags) {
-        String type = cleanValue(tags.getTag("type"), false);
+        String type = cleanValue(tags.getTag(DataSourceType.KEY), false);
         String instanceName = cleanValue(tags.getTag("instance"), false);
         String name = cleanupIllegalCharacters(config.getName(), false);
 

--- a/servo-graphite/src/test/java/com/netflix/servo/publish/graphite/BasicGraphiteNamingConventionTest.java
+++ b/servo-graphite/src/test/java/com/netflix/servo/publish/graphite/BasicGraphiteNamingConventionTest.java
@@ -16,6 +16,7 @@
 package com.netflix.servo.publish.graphite;
 
 import com.netflix.servo.Metric;
+import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.publish.JmxMetricPoller;
 import com.netflix.servo.publish.LocalJmxConnector;
 import com.netflix.servo.publish.MetricPoller;
@@ -56,7 +57,7 @@ public class BasicGraphiteNamingConventionTest {
 
     @Test
     public void testMetricNamingWithTags() throws Exception {
-        TagList tagList = BasicTagList.of("instance", "GetLogs", "type",
+        TagList tagList = BasicTagList.of("instance", "GetLogs", DataSourceType.KEY,
                 "HystrixCommand");
 
         Metric m = new Metric("simpleMonitor", tagList, 0, 1000.0);


### PR DESCRIPTION
...the ObjectNameMapper interface. Added an ordered based mapper which maps known properties in a given order which is useful for tools such as VisualVM who use the ordering to build the viewable mbean hierarchy, also this provides the option of not appending the additional tags but this should be used with care to prevent name collisions. Allow the "type" tag to be configurable via the servo.datasourcetype.key system property as tools such as VisualVM always order "type" at the top of the hierarchy. Replaced hard references then to "type". Resolves #155.
