### PR TITLE
Allow the JMX ObjectNameMapper to be specified as a property (com.netfli...

### DIFF
--- a/servo-core/src/test/java/com/netflix/servo/DefaultMonitorRegistryTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/DefaultMonitorRegistryTest.java
@@ -17,12 +17,18 @@ package com.netflix.servo;
 
 import com.google.common.collect.Sets;
 import com.netflix.servo.jmx.JmxMonitorRegistry;
+import com.netflix.servo.jmx.ObjectNameMapper;
+import com.netflix.servo.monitor.BasicCounter;
 import com.netflix.servo.monitor.Monitor;
 import com.netflix.servo.monitor.MonitorConfig;
+
 import org.testng.annotations.Test;
 
+import java.lang.management.ManagementFactory;
 import java.util.Properties;
 import java.util.Set;
+
+import javax.management.ObjectName;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -136,4 +142,43 @@ public class DefaultMonitorRegistryTest {
         assertTrue(monitors.contains(m1));
         assertTrue(monitors.contains(m2));
     }*/
+
+    @Test
+    public void testCustomJmxObjectMapper() {
+        Properties props = new Properties();
+        props.put("com.netflix.servo.DefaultMonitorRegistry.jmxMapperClass",
+                "com.netflix.servo.DefaultMonitorRegistryTest$ChangeDomainMapper");
+        DefaultMonitorRegistry registry = new DefaultMonitorRegistry(props);
+        BasicCounter counter = new BasicCounter(
+                new MonitorConfig.Builder("testCustomJmxObjectMapper").build());
+        registry.register(counter);
+        ObjectName expectedName =
+                new ChangeDomainMapper().createObjectName("com.netflix.servo", counter);
+        assertEquals(expectedName.getDomain(), "com.netflix.servo.Renamed");
+        assertTrue(ManagementFactory.getPlatformMBeanServer().isRegistered(expectedName));
+    }
+
+    @Test
+    public void testInvalidMapperDefaults() {
+        Properties props = new Properties();
+        props.put("com.netflix.servo.DefaultMonitorRegistry.jmxMapperClass",
+                "com.my.invalid.class");
+        DefaultMonitorRegistry registry = new DefaultMonitorRegistry(props);
+        BasicCounter counter = new BasicCounter(
+                new MonitorConfig.Builder("testInvalidMapperDefaults").build());
+        registry.register(counter);
+        ObjectName expectedName =
+                ObjectNameMapper.DEFAULT.createObjectName("com.netflix.servo", counter);
+        assertEquals(expectedName.getDomain(), "com.netflix.servo");
+        assertTrue(ManagementFactory.getPlatformMBeanServer().isRegistered(expectedName));
+    }
+
+    public static class ChangeDomainMapper implements ObjectNameMapper {
+
+        @Override
+        public ObjectName createObjectName(String domain, Monitor<?> monitor) {
+            return ObjectNameMapper.DEFAULT.createObjectName(domain + ".Renamed", monitor);
+        }
+
+    }
 }


### PR DESCRIPTION
...x.servo.DefaultMonitorRegistry.jmxMapperClass) when the DefaultMonitorRegistry is bootstrapped.
