### PR TITLE
Do not update the last update time if the thread is gone.

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/util/ThreadCpuStats.java
+++ b/servo-core/src/main/java/com/netflix/servo/util/ThreadCpuStats.java
@@ -446,7 +446,7 @@ public final class ThreadCpuStats {
          */
         private void updateNoValue() {
             final int currentPos = toIndex(nextPos.get() - 1);
-            update(totals.get(currentPos));
+            totals.set(toIndex(nextPos.getAndIncrement()), totals.get(currentPos));
         }
     }
 


### PR DESCRIPTION
Do not update the last update time if the thread is gone. This prevents the thread from getting deleted from the usage map and the list of threads keeps growing.
