### PR TITLE
Fix compat check for release build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,12 +73,12 @@ subprojects {
 project(':servo-core') {
   task(checkCompatibility, dependsOn: 'jar', type: JavaExec) {
     // There is probably a better way, but we remove "-SNAPSHOT" from the name if the archive
-    // doesn't exist because release plugin changes the name.
+    // status is not "snapshot".
     main = 'com.googlecode.japi.checker.cli.Main'
     classpath = files("$projectDir/../codequality/japi-checker-cli-0.2.0-SNAPSHOT.jar")
     args = [
       "$projectDir/../codequality/servo-core-BASELINE.jar",
-      (jar.archivePath.exists())
+      (project.status == 'snapshot')
         ? jar.archivePath.path
         : jar.archivePath.path.replace("-SNAPSHOT", "")
     ]


### PR DESCRIPTION
Allow both snapshot and release version of jar when performing the compatibility check.
