### PR TITLE
Remove deprecation from Contextual monitors. 

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/monitor/AbstractContextualMonitor.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/AbstractContextualMonitor.java
@@ -28,9 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Base class used to simplify creation of contextual monitors.
- * @deprecated This is an abstraction that hasn't proved useful. It will be removed in a future release.
  */
-@Deprecated
 public abstract class AbstractContextualMonitor<T, M extends Monitor<T>>
         implements CompositeMonitor<T> {
 

--- a/servo-core/src/main/java/com/netflix/servo/monitor/ContextualCounter.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/ContextualCounter.java
@@ -22,9 +22,7 @@ import com.netflix.servo.tag.TaggingContext;
 /**
  * Composite that maintains separate simple counters for each distinct set of tags returned by the
  * tagging context.
- * @deprecated This is an abstraction that hasn't proved useful. It will be removed in a future release.
  */
-@Deprecated
 public class ContextualCounter extends AbstractContextualMonitor<Number, Counter>
         implements Counter {
 

--- a/servo-core/src/main/java/com/netflix/servo/monitor/ContextualTimer.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/ContextualTimer.java
@@ -24,9 +24,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Composite that maintains separate simple timers for each distinct set of tags returned by the
  * tagging context.
- * @deprecated This is an abstraction that hasn't proved useful. It will be removed in a future release.
  */
-@Deprecated
 public class ContextualTimer extends AbstractContextualMonitor<Long, Timer> implements Timer {
 
     /**

--- a/servo-core/src/main/java/com/netflix/servo/tag/TaggingContext.java
+++ b/servo-core/src/main/java/com/netflix/servo/tag/TaggingContext.java
@@ -19,9 +19,7 @@ package com.netflix.servo.tag;
  * Returns the set of tags associated with the current execution context.
  * Implementations of this interface are used to provide a common set of tags
  * for all contextual monitors in a given execution flow.
- * @deprecated This is an abstraction that hasn't proved useful. It will be removed in a future release.
  */
-@Deprecated
 public interface TaggingContext {
     /** Returns the tags for the current execution context. */
     TagList getTags();

--- a/servo-core/src/main/java/com/netflix/servo/tag/ThreadLocalTaggingContext.java
+++ b/servo-core/src/main/java/com/netflix/servo/tag/ThreadLocalTaggingContext.java
@@ -20,9 +20,7 @@ package com.netflix.servo.tag;
  * current thread. Can be used to customize the context for code executed in
  * a particular thread. For example, on a server with a thread per request the
  * context can be set so metrics will be tagged accordingly.
- * @deprecated This is an abstraction that hasn't proved useful. It will be removed in a future release.
  */
-@Deprecated
 public final class ThreadLocalTaggingContext implements TaggingContext {
 
     private final ThreadLocal<TagList> context = new ThreadLocal<TagList>();


### PR DESCRIPTION
There are valid use cases using these abstractions.
