### PR TITLE
license-gradle-plugin:0.10.0

### DIFF
--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -4,7 +4,7 @@ repositories {
     repositories { maven { url 'http://dl.bintray.com/content/netflixoss/external-gradle-plugins/' } } // For gradle-release
 }
 dependencies {
-    classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.6.1'
+    classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.10.0'
     classpath 'com.mapvine:gradle-cobertura-plugin:0.1'
     classpath 'gradle-release:gradle-release:1.1.5'
     classpath 'org.ajoberstar:gradle-git:0.5.0'


### PR DESCRIPTION
This version will cause the build to fail
if the license headers are incorrect.
