### PR TITLE
upgrade to aws-java-sdk-1.9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,8 @@ project(':servo-apache') {
 project(':servo-aws') {
     dependencies {
         compile project(':servo-core')
-        compile('com.amazonaws:aws-java-sdk:1.8.10.2')
+        compile('com.amazonaws:aws-java-sdk-autoscaling:1.9.3')
+        compile('com.amazonaws:aws-java-sdk-cloudwatch:1.9.3')
     }
 }
 


### PR DESCRIPTION
As of 1.9.0, the aws-java-sdk has been
broken up into multiple projects. This
change also changes the dependency to
just the cloudwatch and autoscaling
libraries that we use.
