### PR TITLE
Removes race condition in JmxMonitorRegistry.register

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/jmx/JmxMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/jmx/JmxMonitorRegistry.java
@@ -78,10 +78,12 @@ public final class JmxMonitorRegistry implements MonitorRegistry {
     }
 
     private void register(ObjectName objectName, DynamicMBean mbean) throws Exception {
-        if (mBeanServer.isRegistered(objectName)) {
-            mBeanServer.unregisterMBean(objectName);
+        synchronized (mBeanServer) {
+            if (mBeanServer.isRegistered(objectName)) {
+                mBeanServer.unregisterMBean(objectName);
+            }
+            mBeanServer.registerMBean(mbean, objectName);
         }
-        mBeanServer.registerMBean(mbean, objectName);
     }
 
     /**


### PR DESCRIPTION
The MBeanServer used in JmxMonitorRegistry is shared across the VM.
Calls to register will occur from different threads, and results in a
race, particularly as names can easily clash.

By synchronizing on the mBeanServer, we can ensure the guard works
without introducing a complicated loop of catching
InstanceNotFoundException or InstanceAlreadyExistsException.

See https://github.com/Netflix/feign/issues/182