### PR TITLE
Tag with key "statistic" is propagated in namespace of grapthite when da...

### DIFF
--- a/servo-graphite/src/main/java/com/netflix/servo/publish/graphite/BasicGraphiteNamingConvention.java
+++ b/servo-graphite/src/main/java/com/netflix/servo/publish/graphite/BasicGraphiteNamingConvention.java
@@ -46,6 +46,7 @@ public class BasicGraphiteNamingConvention implements GraphiteNamingConvention {
         String type = cleanValue(tags.getTag(DataSourceType.KEY), false);
         String instanceName = cleanValue(tags.getTag("instance"), false);
         String name = cleanupIllegalCharacters(config.getName(), false);
+        String statistic = cleanValue(tags.getTag("statistic"), false);
 
         StringBuilder nameBuilder = new StringBuilder();
         if (type != null) {
@@ -56,6 +57,9 @@ public class BasicGraphiteNamingConvention implements GraphiteNamingConvention {
         }
         if (name != null) {
             nameBuilder.append(name).append(".");
+        }
+        if (statistic != null){
+            nameBuilder.append(statistic).append(".");
         }
         // remove trailing "."
         nameBuilder.deleteCharAt(nameBuilder.lastIndexOf("."));

--- a/servo-graphite/src/main/java/com/netflix/servo/publish/graphite/GraphiteMetricObserver.java
+++ b/servo-graphite/src/main/java/com/netflix/servo/publish/graphite/GraphiteMetricObserver.java
@@ -41,6 +41,7 @@ import java.util.List;
  */
 public class GraphiteMetricObserver extends BaseMetricObserver {
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphiteMetricObserver.class);
+    private static final String STATISTIC_TAG_KEY = "statistic";
 
     private final GraphiteNamingConvention namingConvention;
     private final String serverPrefix;
@@ -145,14 +146,25 @@ public class GraphiteMetricObserver extends BaseMetricObserver {
             if (serverPrefix != null) {
                 sb.append(serverPrefix).append(".");
             }
-            sb.append(publishedName).append(" ");
-            sb.append(metric.getValue().toString()).append(" ");
+            sb.append(publishedName);
+            if(hasStatisticTag(metric)) {
+                sb.append(".").append(getStatisticTagValue(metric));
+            }
+            sb.append(" ").append(metric.getValue().toString()).append(" ");
             sb.append(metric.getTimestamp() / 1000);
             LOGGER.debug("{}", sb);
             writer.write(sb.append("\n").toString());
             count++;
         }
         return count;
+    }
+
+    private boolean hasStatisticTag(Metric metric){
+        return metric.getConfig().getTags().containsKey(STATISTIC_TAG_KEY);
+    }
+
+    private String getStatisticTagValue(Metric metric){
+        return metric.getConfig().getTags().getTag(STATISTIC_TAG_KEY).getValue();
     }
 
     /**

--- a/servo-graphite/src/main/java/com/netflix/servo/publish/graphite/GraphiteMetricObserver.java
+++ b/servo-graphite/src/main/java/com/netflix/servo/publish/graphite/GraphiteMetricObserver.java
@@ -41,7 +41,6 @@ import java.util.List;
  */
 public class GraphiteMetricObserver extends BaseMetricObserver {
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphiteMetricObserver.class);
-    private static final String STATISTIC_TAG_KEY = "statistic";
 
     private final GraphiteNamingConvention namingConvention;
     private final String serverPrefix;
@@ -146,25 +145,14 @@ public class GraphiteMetricObserver extends BaseMetricObserver {
             if (serverPrefix != null) {
                 sb.append(serverPrefix).append(".");
             }
-            sb.append(publishedName);
-            if(hasStatisticTag(metric)) {
-                sb.append(".").append(getStatisticTagValue(metric));
-            }
-            sb.append(" ").append(metric.getValue().toString()).append(" ");
+            sb.append(publishedName).append(" ");
+            sb.append(metric.getValue().toString()).append(" ");
             sb.append(metric.getTimestamp() / 1000);
             LOGGER.debug("{}", sb);
             writer.write(sb.append("\n").toString());
             count++;
         }
         return count;
-    }
-
-    private boolean hasStatisticTag(Metric metric){
-        return metric.getConfig().getTags().containsKey(STATISTIC_TAG_KEY);
-    }
-
-    private String getStatisticTagValue(Metric metric){
-        return metric.getConfig().getTags().getTag(STATISTIC_TAG_KEY).getValue();
     }
 
     /**


### PR DESCRIPTION
This improvement fix how  properties of Timers were propagated. For example BasicTimer has four properties (min, max, count, sum) and only two of them were propagated into graphite  One propagated property was count and second was not firmly defined and could it be one of the rest.

Now all properties are propagated into graphite (Tested with BasicTimer).