### PR TITLE
Logging warning when mbean query doesn't match any mbeans

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/publish/JmxMetricPoller.java
+++ b/servo-core/src/main/java/com/netflix/servo/publish/JmxMetricPoller.java
@@ -222,11 +222,15 @@ public final class JmxMetricPoller implements MetricPoller {
             MBeanServerConnection con = connector.getConnection();
             for (ObjectName query : queries) {
                 Set<ObjectName> names = con.queryNames(query, null);
-                for (ObjectName name : names) {
-                    try {
-                        getMetrics(con, filter, metrics, name);
-                    } catch (Exception e) {
-                        LOGGER.warn("failed to get metrics for: " + name, e);
+                if (names.isEmpty()) {
+                    LOGGER.warn("no mbeans matched query: {}", query);
+                } else {
+                    for (ObjectName name : names) {
+                        try {
+                            getMetrics(con, filter, metrics, name);
+                        } catch (Exception e) {
+                            LOGGER.warn("failed to get metrics for: " + name, e);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This change fixes #310.