### PR TITLE
Some extensions to JmxMetricsPoller

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/publish/JmxMetricPoller.java
+++ b/servo-core/src/main/java/com/netflix/servo/publish/JmxMetricPoller.java
@@ -102,9 +102,10 @@ public final class JmxMetricPoller implements MetricPoller {
      * @param queries    object name patterns for selecting mbeans
      * @param counters   metrics matching this filter will be treated as
      *                   counters, all others will be gauges
-     * @param onlyNumericMetrics only produce metrics that can be converted to a Number (filter out all strings, etc)
-     * @param defaultTags a list of tags to attach to all metrics, usually useful to identify all metrics from
-     *                    a given application or hostname
+     * @param onlyNumericMetrics only produce metrics that can be converted to a Number
+     *                           (filter out all strings, etc)
+     * @param defaultTags a list of tags to attach to all metrics, usually
+     *                    useful to identify all metrics from a given application or hostname
      */
     public JmxMetricPoller(
             JmxConnector connector, List<ObjectName> queries, MetricFilter counters,
@@ -128,7 +129,7 @@ public final class JmxMetricPoller implements MetricPoller {
         }
         tags.add(Tags.newTag(DOMAIN_KEY, name.getDomain()));
         tags.add(CLASS_TAG);
-        if(defaultTags != null) {
+        if (defaultTags != null) {
             for (Tag defaultTag : defaultTags) {
                 tags.add(defaultTag);
             }
@@ -216,7 +217,8 @@ public final class JmxMetricPoller implements MetricPoller {
         }
     }
 
-    private void addCompositeMetrics(MetricFilter filter, List<Metric> metrics, TagList tags, String attrName, CompositeData obj) {
+    private void addCompositeMetrics(MetricFilter filter, List<Metric> metrics, TagList tags,
+                                     String attrName, CompositeData obj) {
         Map<String, Object> values = new HashMap<String, Object>();
         extractValues(null, values, obj);
         for (Map.Entry<String, Object> e : values.entrySet()) {
@@ -231,7 +233,8 @@ public final class JmxMetricPoller implements MetricPoller {
         }
     }
 
-    private void addTabularMetrics(MetricFilter filter, List<Metric> metrics, TagList tags, String attrName, CompositeData obj) {
+    private void addTabularMetrics(MetricFilter filter, List<Metric> metrics, TagList tags,
+                                   String attrName, CompositeData obj) {
         Map<String, Object> values = new HashMap<String, Object>();
         // tabular composite data has a value called key and one called value
         values.put(obj.get("key").toString(), obj.get("value"));

--- a/servo-core/src/test/java/com/netflix/servo/publish/JmxMetricPollerTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/publish/JmxMetricPollerTest.java
@@ -17,9 +17,15 @@ package com.netflix.servo.publish;
 
 import com.netflix.servo.Metric;
 import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.monitor.MonitorConfig;
 import org.testng.annotations.Test;
 
+import javax.management.MBeanServer;
 import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -76,4 +82,66 @@ public class JmxMetricPollerTest {
         assertTrue(found);
     }
 
+    /**
+     * Tabular JMX values are very useful for cases where we want the same behavior as CompositePath but we
+     * don't know up front what the values are going to be.
+     */
+    @Test
+    public void testTabularData() throws Exception {
+
+        MapMXBean mapMXBean = new MapMXBean();
+        try {
+            MetricPoller poller = new JmxMetricPoller(
+                    new LocalJmxConnector(),
+                    new ObjectName("com.netflix.servo.test:*"),
+                    MATCH_ALL);
+
+            List<Metric> metrics = poller.poll(new MetricFilter() {
+                @Override
+                public boolean matches(MonitorConfig config) {
+                    return config.getName().equals("Count");
+                }
+            });
+            assertEquals(metrics.size(), 2);
+            Map<String, Integer> values = new HashMap<String, Integer>();
+            for (Metric m : metrics) {
+                values.put(m.getConfig().getTags().getTag("JmxCompositePath").getValue(), (Integer)m.getValue());
+            }
+            assertEquals(values.get("Entry1"), (Integer)111);
+            assertEquals(values.get("Entry2"), (Integer)222);
+        } finally {
+            mapMXBean.destroy();
+        }
+    }
+
+    public interface TestMapMXBean {
+        Map<String, Integer> getCount();
+    }
+
+    public static class MapMXBean implements TestMapMXBean {
+
+        private final ObjectName objectName;
+
+        MapMXBean() throws Exception {
+            MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            objectName = new ObjectName("com.netflix.servo.test", "Test", "Obj");
+            destroy();
+            mbs.registerMBean(this, objectName);
+        }
+
+        public void destroy() throws Exception {
+            MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            if (mbs.isRegistered(objectName)) {
+                mbs.unregisterMBean(objectName);
+            }
+        }
+
+        @Override
+        public Map<String, Integer> getCount() {
+            Map<String, Integer> map = new HashMap<String, Integer>();
+            map.put("Entry1", 111);
+            map.put("Entry2", 222);
+            return map;
+        }
+    }
 }


### PR DESCRIPTION
This class turns out to a very useful building block for doing JMX collection and with a few additions can be even more useful.

3 small enhancements to JmxMetricsPoller:
* Parses TablularData like it was CompositeData
* Option to not filter out non-numeric metrics (useful when making a "JMX Dump" like tool that isn't feeding a monitoring system)
* Ability to add default tags to every metric to help identify the source (without needing an Observer for each host since we already have to have a poller for every host)

