### PR TITLE
update to guava 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,11 +55,11 @@ subprojects {
   }
 
   dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.7'
-    compile 'com.google.guava:guava:14.0.1'
+    compile 'org.slf4j:slf4j-api:1.7.12'
+    compile 'com.google.guava:guava:16.0.1'
     compile 'com.google.code.findbugs:annotations:2.0.0'
     testCompile 'org.testng:testng:6.1.1'
-    testRuntime 'org.slf4j:slf4j-log4j12:1.7.7'
+    testRuntime 'org.slf4j:slf4j-log4j12:1.7.12'
     testRuntime 'log4j:log4j:1.2.17'
   }
 


### PR DESCRIPTION
Internal platform is moving to guava 16. This doesn't
require any code changes on our side, just moving the
dependency to keep things consistent.