### PR TITLE
Replace regex replaceAll with hand crafted version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,16 @@
  */
 
 plugins {
-  id 'nebula.netflixoss' version '2.2.5'
+  id 'nebula.netflixoss' version '2.2.9'
+  id 'me.champeau.gradle.jmh' version '0.2.0'
 }
 
 ext {
   githubProjectName = 'servo'
+}
+
+allprojects {
+  apply plugin: 'me.champeau.gradle.jmh'
 }
 
 subprojects {
@@ -61,6 +66,15 @@ subprojects {
     testCompile 'org.testng:testng:6.1.1'
     testRuntime 'org.slf4j:slf4j-log4j12:1.7.12'
     testRuntime 'log4j:log4j:1.2.17'
+    jmh 'org.slf4j:slf4j-simple:1.7.12'
+  }
+
+  jmh {
+    warmupIterations = 2
+    iterations = 10
+    fork = 5
+    profilers = ['STACK']
+    include '.*'
   }
 
   checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ subprojects {
 
   findbugs {
     ignoreFailures = false 
+    sourceSets = [sourceSets.main]
   }
 
   tasks.withType(FindBugs) {

--- a/servo-atlas/build.gradle
+++ b/servo-atlas/build.gradle
@@ -4,4 +4,5 @@ dependencies {
   compile 'com.netflix.iep-shadow:iepshadow-iep-rxhttp:0.1.22.0' 
   compile "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jackson_version}"
+  jmh project(':servo-core')
 }

--- a/servo-atlas/src/jmh/java/com/netflix/servo/publish/atlas/ValidCharactersBench.java
+++ b/servo-atlas/src/jmh/java/com/netflix/servo/publish/atlas/ValidCharactersBench.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo.publish.atlas;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.regex.Pattern;
+
+@State(Scope.Thread)
+public class ValidCharactersBench {
+    private static final Pattern INVALID_CHARS = Pattern.compile("[^a-zA-Z0-9_\\-\\.]");
+
+    static String oldRegexMethod(String str) {
+        return INVALID_CHARS.matcher(str).replaceAll("_");
+    }
+
+    @Threads(1)
+    @Benchmark
+    public void testUsingRegex(Blackhole bh) {
+        String sourceStr = "netflix.streaming.vhs.server.pbstats.bitrate.playedSecs";
+        bh.consume(oldRegexMethod(sourceStr));
+    }
+
+    @Threads(1)
+    @Benchmark
+    public void testNewByHand(Blackhole bh) {
+        String sourceStr = "netflix.streaming.vhs.server.pbstats.bitrate.playedSecs";
+        bh.consume(ValidCharacters.toValidCharset(sourceStr));
+    }
+}

--- a/servo-atlas/src/main/java/com/netflix/servo/publish/atlas/ValidCharacters.java
+++ b/servo-atlas/src/main/java/com/netflix/servo/publish/atlas/ValidCharacters.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Netflix, Inc.
- *
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,50 +21,75 @@ import com.netflix.servo.tag.Tag;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * Utility class to deal with rewriting keys/values to the character set accepted by atlas.
  */
 public final class ValidCharacters {
-  /**
-   * Only allow letters, numbers, underscores, dashes and dots in our identifiers.
-   */
-  private static final Pattern INVALID_CHARS = Pattern.compile("[^a-zA-Z0-9_\\-\\.]");
+    /**
+     * Only allow letters, numbers, underscores, dashes and dots in our identifiers.
+     */
 
-  private ValidCharacters() {
-    // utility class
-  }
+    private static boolean[] charIsAllowed = new boolean[128];
 
-  /**
-   * Convert a given string to one where all characters are valid.
-   */
-  public static String toValidCharset(String str) {
-    return INVALID_CHARS.matcher(str).replaceAll("_");
-  }
-
-  /**
-   * Return a new metric where the name and all tags are using the valid character
-   * set.
-   */
-  public static Metric toValidValue(Metric metric) {
-    MonitorConfig cfg = metric.getConfig();
-    MonitorConfig.Builder cfgBuilder = MonitorConfig.builder(toValidCharset(cfg.getName()));
-    for (Tag orig : cfg.getTags()) {
-      cfgBuilder.withTag(toValidCharset(orig.getKey()), toValidCharset(orig.getValue()));
+    static {
+        charIsAllowed['.'] = true;
+        charIsAllowed['-'] = true;
+        charIsAllowed['_'] = true;
+        for (char ch = '0'; ch <= '9'; ch++) {
+            charIsAllowed[ch] = true;
+        }
+        for (char ch = 'A'; ch <= 'Z'; ch++) {
+            charIsAllowed[ch] = true;
+        }
+        for (char ch = 'a'; ch <= 'z'; ch++) {
+            charIsAllowed[ch] = true;
+        }
     }
-    cfgBuilder.withPublishingPolicy(cfg.getPublishingPolicy());
-    return new Metric(cfgBuilder.build(), metric.getTimestamp(), metric.getValue());
-  }
 
-  /**
-   * Create a new list of metrics where all metrics are using the valid character set.
-   */
-  public static List<Metric> toValidValues(List<Metric> metrics) {
-    List<Metric> fixedMetrics = new ArrayList<Metric>(metrics.size());
-    for (Metric m : metrics) {
-      fixedMetrics.add(toValidValue(m));
+    private ValidCharacters() {
+        // utility class
     }
-    return fixedMetrics;
-  }
+
+    /**
+     * Convert a given string to one where all characters are valid.
+     */
+    public static String toValidCharset(String str) {
+        final int n = str.length();
+        final StringBuilder buf = new StringBuilder(n + 1);
+        for (int i = 0; i < n; i++) {
+            final char c = str.charAt(i);
+            if (c < charIsAllowed.length && charIsAllowed[c]) {
+                buf.append(c);
+            } else {
+                buf.append('_');
+            }
+        }
+        return buf.toString();
+    }
+
+    /**
+     * Return a new metric where the name and all tags are using the valid character
+     * set.
+     */
+    public static Metric toValidValue(Metric metric) {
+        MonitorConfig cfg = metric.getConfig();
+        MonitorConfig.Builder cfgBuilder = MonitorConfig.builder(toValidCharset(cfg.getName()));
+        for (Tag orig : cfg.getTags()) {
+            cfgBuilder.withTag(toValidCharset(orig.getKey()), toValidCharset(orig.getValue()));
+        }
+        cfgBuilder.withPublishingPolicy(cfg.getPublishingPolicy());
+        return new Metric(cfgBuilder.build(), metric.getTimestamp(), metric.getValue());
+    }
+
+    /**
+     * Create a new list of metrics where all metrics are using the valid character set.
+     */
+    public static List<Metric> toValidValues(List<Metric> metrics) {
+        List<Metric> fixedMetrics = new ArrayList<Metric>(metrics.size());
+        for (Metric m : metrics) {
+            fixedMetrics.add(toValidValue(m));
+        }
+        return fixedMetrics;
+    }
 }

--- a/servo-atlas/src/test/java/com/netflix/servo/publish/atlas/ValidCharactersTest.java
+++ b/servo-atlas/src/test/java/com/netflix/servo/publish/atlas/ValidCharactersTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo.publish.atlas;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class ValidCharactersTest {
+    @Test
+    public void testValidStrIsUnchanged() throws Exception {
+        String valid = "abc09.-_";
+        assertEquals(ValidCharacters.toValidCharset(valid), valid);
+    }
+
+    @Test
+    public void testInvalidStrIsFixed() throws Exception {
+        String str = "abc09.-_ abc";
+        assertEquals(ValidCharacters.toValidCharset(str), "abc09.-__abc");
+
+        String boundaries = "\u0000\u0128\uffff";
+        assertEquals(ValidCharacters.toValidCharset(boundaries), "___");
+    }
+}


### PR DESCRIPTION
Update ValidCharacters.toValidCharset to use a hand crafted version.

The new version is around 5x faster than the previous regex based version:

```
c.n.s.p.a.ValidCharactersBench.testNewByHand     thrpt       50  4258892.253 ± 57887.069  ops/s
c.n.s.p.a.ValidCharactersBench.testUsingRegex    thrpt       50   923106.236 ±  8753.248  ops/s
```