### PR TITLE
Deal with new apache status output

### DIFF
--- a/servo-apache/src/test/java/com/netflix/servo/publish/apache/ApacheStatusPollerTest.java
+++ b/servo-apache/src/test/java/com/netflix/servo/publish/apache/ApacheStatusPollerTest.java
@@ -23,8 +23,6 @@ import com.netflix.servo.util.UnmodifiableList;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -77,6 +75,78 @@ public class ApacheStatusPollerTest {
   public void testParse() throws Exception {
     final String statusText = "Total Accesses: " + TOTAL_ACCESSES + "\n"
         + "Total kBytes: " + KBYTES + "\n"
+        + "CPULoad: .044688\n"
+        + "Uptime: " + UPTIME + "\n"
+        + "ReqPerSec: " + RPS + "\n"
+        + "BytesPerSec: " + BPS + "\n"
+        + "BytesPerReq: " + BPR + "\n"
+        + "BusyWorkers: " + BUSY_WORKERS + "\n"
+        + "IdleWorkers: " + IDLE_WORKERS + "\n"
+        + "Scoreboard: __________________K___W_K_____K______________K____"
+        + repeat('.', OPEN_SLOTS)
+        + "\n";
+    ApacheStatusPoller.StatusFetcher fetcher = () -> new ByteArrayInputStream(statusText.getBytes("UTF-8"));
+
+    ApacheStatusPoller poller = new ApacheStatusPoller(fetcher);
+
+    List<Metric> metrics = poller.pollImpl(TIMESTAMP);
+
+    Metric accesses = counter("Total_Accesses", TOTAL_ACCESSES);
+    Metric kBytes = counter("Total_kBytes", KBYTES);
+    Metric uptime = counter("Uptime", UPTIME);
+
+    List<Metric> counters = UnmodifiableList.of(accesses, kBytes, uptime);
+    Metric rps = gauge("ReqPerSec", RPS);
+    Metric bps = gauge("BytesPerSec", BPS);
+    Metric bpr = gauge("BytesPerReq", BPR);
+    Metric busyWorkers = gauge("BusyWorkers", BUSY_WORKERS);
+    Metric idleWorkers = gauge("IdleWorkers", IDLE_WORKERS);
+    List<Metric> gauges = UnmodifiableList.of(rps, bps, bpr, busyWorkers, idleWorkers);
+
+    Metric waitingForConnection = scoreboard("WaitingForConnection", 45.0);
+    Metric startingUp = scoreboard("StartingUp", 0.0);
+    Metric readingRequest = scoreboard("ReadingRequest", 0.0);
+    Metric sendingReply = scoreboard("SendingReply", 1.0);
+    Metric keepalive = scoreboard("Keepalive", 4.0);
+    Metric dnsLookup = scoreboard("DnsLookup", 0.0);
+    Metric closingConnection = scoreboard("ClosingConnection", 0.0);
+    Metric logging = scoreboard("Logging", 0.0);
+    Metric gracefullyFinishing = scoreboard("GracefullyFinishing", 0.0);
+    Metric idleCleanupOfWorker = scoreboard("IdleCleanupOfWorker", 0.0);
+    Metric unknownState = scoreboard("UnknownState", 0.0);
+    List<Metric> scoreboard = UnmodifiableList.of(waitingForConnection,
+        startingUp, readingRequest, sendingReply, keepalive, dnsLookup, closingConnection,
+        logging, gracefullyFinishing, idleCleanupOfWorker, unknownState);
+
+    List<Metric> expected = new ArrayList<>();
+    expected.addAll(counters);
+    expected.addAll(gauges);
+    expected.addAll(scoreboard);
+
+    assertEquals(metrics, expected);
+  }
+
+  @Test
+  public void testParseNewFormat() throws Exception {
+    final String statusText = "localhost\n"
+        + "ServerVersion: Apache/2.4.16 (Ubuntu)\n"
+        + "ServerMPM: worker\n"
+        + "Server Built: 2015-09-08T00:00:00\n"
+        + "CurrentTime: Tuesday, 08-Sep-2015 21:07:08 UTC\n"
+        + "RestartTime: Tuesday, 08-Sep-2015 19:51:38 UTC\n"
+        + "ParentServerConfigGeneration: 1\n"
+        + "ParentServerMPMGeneration: 0\n"
+        + "ServerUptimeSeconds: \n"
+        + "ServerUptime: 1 hour 15 minutes 29 seconds\n"
+        + "Load1: 0.04\n"
+        + "Load5: 0.03\n"
+        + "Load15: 0.05\n"
+        + "Total Accesses: " + TOTAL_ACCESSES + "\n"
+        + "Total kBytes: " + KBYTES + "\n"
+        + "CPUUser: .36\n"
+        + "CPUSystem: .26\n"
+        + "CPUChildrenUser: 0\n"
+        + "CPUChildrenSystem: 0\n"
         + "CPULoad: .044688\n"
         + "Uptime: " + UPTIME + "\n"
         + "ReqPerSec: " + RPS + "\n"


### PR DESCRIPTION
Change the apache status parsing to only generate a set of whitelisted metrics.