### PR TITLE
totalOfSquares replaces minGauge in BasicTimer

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/monitor/DoubleCounter.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/DoubleCounter.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo.monitor;
+
+import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.util.Clock;
+import com.netflix.servo.util.VisibleForTesting;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A simple counter implementation backed by a StepLong but using doubles.
+ * The value returned is a rate for the
+ * previous interval as defined by the step.
+ */
+class DoubleCounter extends AbstractMonitor<Number> implements NumericMonitor<Number> {
+
+  private final StepLong count;
+
+  /**
+   * Creates a new instance of the counter.
+   */
+  DoubleCounter(MonitorConfig config, Clock clock) {
+    // This class will reset the value so it is not a monotonically increasing value as
+    // expected for type=COUNTER. This class looks like a counter to the user and a gauge to
+    // the publishing pipeline receiving the value.
+    super(config.withAdditionalTag(DataSourceType.NORMALIZED));
+    count = new StepLong(0L, clock);
+  }
+
+  private void add(AtomicLong num, double amount) {
+    long v;
+    double d;
+    long next;
+    do {
+      v = num.get();
+      d = Double.longBitsToDouble(v);
+      next = Double.doubleToLongBits(d + amount);
+    } while (!num.compareAndSet(v, next));
+  }
+
+  /**
+   * Increment the value by the specified amount.
+   */
+  void increment(double amount) {
+    if (amount >= 0.0) {
+      for (int i = 0; i < Pollers.NUM_POLLERS; ++i) {
+        add(count.getCurrent(i), amount);
+      }
+    }
+  }
+
+  @Override
+  public Number getValue(int pollerIndex) {
+    final Datapoint dp = count.poll(pollerIndex);
+    final double stepSeconds = Pollers.POLLING_INTERVALS[pollerIndex] / 1000.0;
+    return dp.isUnknown() ? Double.NaN : Double.longBitsToDouble(dp.getValue()) / stepSeconds;
+  }
+
+  /**
+   * Get the current count for the given poller index.
+   */
+  @VisibleForTesting
+  public double getCurrentCount(int pollerIndex) {
+    return Double.longBitsToDouble(count.getCurrent(pollerIndex).get());
+  }
+
+  @Override
+  public String toString() {
+    return "DoubleCounter{"
+        + "config=" + config
+        + "count=" + Double.longBitsToDouble(count.getCurrent(0).longValue())
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DoubleCounter that = (DoubleCounter) o;
+    return config.equals(that.config) && Objects.equals(getValue(0), that.getValue(0));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(config, getValue(0));
+  }
+}

--- a/servo-core/src/test/java/com/netflix/servo/monitor/BasicTimerTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/BasicTimerTest.java
@@ -33,34 +33,29 @@ public class BasicTimerTest extends AbstractMonitorTest<BasicTimer> {
     assertEquals(c.getValue().longValue(), 0L);
     assertEquals(c.getTotalTime().longValue(), 0L);
     assertEquals(c.getCount().longValue(), 0L);
-    assertEquals(c.getMin().longValue(), 0L);
     assertEquals(c.getMax().longValue(), 0L);
 
     c.record(42, TimeUnit.MILLISECONDS);
     assertEquals(c.getValue().longValue(), 42L);
     assertEquals(c.getTotalTime().longValue(), 42L);
     assertEquals(c.getCount().longValue(), 1L);
-    assertEquals(c.getMin().longValue(), 42L);
     assertEquals(c.getMax().longValue(), 42L);
 
     c.record(21, TimeUnit.MILLISECONDS);
     assertEquals(c.getValue().longValue(), 31L);
     assertEquals(c.getTotalTime().longValue(), 63L);
     assertEquals(c.getCount().longValue(), 2L);
-    assertEquals(c.getMin().longValue(), 21L);
     assertEquals(c.getMax().longValue(), 42L);
 
     c.record(84, TimeUnit.MILLISECONDS);
     assertEquals(c.getValue().longValue(), 49L);
     assertEquals(c.getTotalTime().longValue(), 147L);
     assertEquals(c.getCount().longValue(), 3L);
-    assertEquals(c.getMin().longValue(), 21L);
     assertEquals(c.getMax().longValue(), 84L);
 
     assertEquals(c.getValue().longValue(), 49L);
     assertEquals(c.getTotalTime().longValue(), 147L);
     assertEquals(c.getCount().longValue(), 3L);
-    assertEquals(c.getMin().longValue(), 21L);
     assertEquals(c.getMax().longValue(), 84L);
   }
 
@@ -88,6 +83,5 @@ public class BasicTimerTest extends AbstractMonitorTest<BasicTimer> {
     timer.record(1000, TimeUnit.NANOSECONDS);
     assertEquals(timer.getTotalTime(), 0.001);
     assertEquals(timer.getMax(), 0.001);
-    assertEquals(timer.getMin(), 0.001);
   }
 }

--- a/servo-core/src/test/java/com/netflix/servo/monitor/DoubleCounterTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/DoubleCounterTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo.monitor;
+
+import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.util.ManualClock;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class DoubleCounterTest {
+
+  final ManualClock clock = new ManualClock(50 * Pollers.POLLING_INTERVALS[1]);
+
+  public DoubleCounter newInstance(String name) {
+    return new DoubleCounter(MonitorConfig.builder(name).build(), clock);
+  }
+
+  public long time(long t) {
+    return t * 1000 + Pollers.POLLING_INTERVALS[1] * 50;
+  }
+
+  @Test
+  public void testIncrement() {
+    assertEquals(Pollers.POLLING_INTERVALS[0], 60000L);
+    DoubleCounter c = newInstance("c");
+    c.increment(1.0);
+    assertEquals(c.getCurrentCount(0), 1.0);
+  }
+
+  @Test
+  public void testSimpleTransition() {
+    clock.set(0);
+    DoubleCounter c = newInstance("c");
+    assertEquals(c.getValue(0).doubleValue(), Double.NaN);
+    assertEquals(c.getCurrentCount(0), 0.0);
+
+    clock.set(2000);
+    c.increment(1);
+    assertEquals(c.getValue(0).doubleValue(), Double.NaN);
+    assertEquals(c.getCurrentCount(0), 1.0);
+
+    clock.set(52000);
+    c.increment(1);
+    assertEquals(c.getValue(0).doubleValue(), Double.NaN);
+    assertEquals(c.getCurrentCount(0), 2.0);
+
+    clock.set(62000);
+    c.increment(1);
+    assertEquals(c.getCurrentCount(0), 1.0);
+    assertEquals(c.getValue(0).doubleValue(), 1.0 / 30.0);
+  }
+
+
+  @Test
+  public void testInitialPollIsZero() {
+    clock.set(time(1));
+    DoubleCounter c = newInstance("foo");
+    assertEquals(c.getValue(1).doubleValue(), 0.0);
+  }
+
+  @Test
+  public void testHasRightType() throws Exception {
+    assertEquals(newInstance("foo").getConfig().getTags().getValue(DataSourceType.KEY),
+        "NORMALIZED");
+  }
+
+  @Test
+  public void testBoundaryTransition() {
+    clock.set(time(1));
+    DoubleCounter c = newInstance("foo");
+
+    // Should all go to one bucket
+    c.increment(1);
+    clock.set(time(4));
+    c.increment(1);
+    clock.set(time(9));
+    c.increment(1);
+
+    // Should cause transition
+    clock.set(time(10));
+    c.increment(1);
+    clock.set(time(19));
+    c.increment(1);
+
+    // Check counts
+    assertEquals(c.getValue(1).doubleValue(), 0.3);
+    assertEquals(c.getCurrentCount(1), 2.0);
+  }
+
+  @Test
+  public void testResetPreviousValue() {
+    clock.set(time(1));
+    DoubleCounter c = newInstance("foo");
+    for (int i = 1; i <= 100000; ++i) {
+      c.increment(1);
+      clock.set(time(i * 10 + 1));
+      assertEquals(c.getValue(1).doubleValue(), 0.1);
+    }
+  }
+
+  @Test
+  public void testMissedInterval() {
+    clock.set(time(1));
+    DoubleCounter c = newInstance("foo");
+    c.getValue(1);
+
+    // Multiple updates without polling
+    c.increment(1);
+    clock.set(time(4));
+    c.increment(1);
+    clock.set(time(14));
+    c.increment(1);
+    clock.set(time(24));
+    c.increment(1);
+    clock.set(time(34));
+    c.increment(1);
+
+    // Check counts
+    assertTrue(Double.isNaN(c.getValue(1).doubleValue()));
+    assertEquals(c.getCurrentCount(1), 1.0);
+  }
+
+  @Test
+  public void testNonMonotonicClock() {
+    clock.set(time(1));
+    DoubleCounter c = newInstance("foo");
+    c.getValue(1);
+
+    c.increment(1);
+    c.increment(1);
+    clock.set(time(10));
+    c.increment(1);
+    clock.set(time(9)); // Should get ignored
+    c.increment(1);
+    assertEquals(c.getCurrentCount(1), 2.0);
+    c.increment(1);
+    clock.set(time(10));
+    c.increment(1);
+    c.increment(1);
+    assertEquals(c.getCurrentCount(1), 5.0);
+
+    // Check rate for previous internval
+    assertEquals(c.getValue(1).doubleValue(), 0.2);
+  }
+
+  @Test
+  public void testGetValueTwice() {
+    ManualClock manualClock = new ManualClock(0L);
+
+    DoubleCounter c = new DoubleCounter(MonitorConfig.builder("test").build(), manualClock);
+    c.increment(1);
+    for (int i = 1; i < 10; ++i) {
+      manualClock.set(i * 60000L);
+      c.increment(1);
+      c.getValue(0);
+      assertEquals(c.getValue(0).doubleValue(), 1 / 60.0);
+    }
+  }
+}


### PR DESCRIPTION
The 'min' gauge in a BasicTimer has not proven useful in practice. Timers that don't get updated will report 0, which makes the aggregate value of dubious value.

This PR replaces the min gauge with a totalOfSquares counter that can be used to accurately compute the standard deviation of samples recorded.