### PR TITLE
Fix silent failure publishing to CloudWatch.

### DIFF
--- a/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
+++ b/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
@@ -179,15 +179,13 @@ public class CloudWatchMetricObserver extends BaseMetricObserver {
     Preconditions.checkNotNull(metrics, "metrics");
 
     List<Metric> batch = new ArrayList<>(batchSize);
-    int batchCount = 1;
 
     while (!metrics.isEmpty()) {
       Metric m = metrics.remove(0);
       if (m.hasNumberValue()) {
         batch.add(m);
 
-        if (batchCount % batchSize == 0) {
-          ++batchCount;
+        if (batch.size() % batchSize == 0) {
           putMetricData(batch);
           batch.clear();
         }


### PR DESCRIPTION
CloudWatch has a max 20 metrics per request limit. This fixes servo publishing
all metrics above the 20 limit without batching.