### PR TITLE
update guava and aws sdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,12 +60,12 @@ subprojects {
   }
 
   dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.12'
-    compile 'com.google.guava:guava:16.0.1'
+    compile 'org.slf4j:slf4j-api:1.7.13'
+    compile 'com.google.guava:guava:18.0'
     testCompile 'org.testng:testng:6.1.1'
-    testRuntime 'org.slf4j:slf4j-log4j12:1.7.12'
+    testRuntime 'org.slf4j:slf4j-log4j12:1.7.13'
     testRuntime 'log4j:log4j:1.2.17'
-    jmh 'org.slf4j:slf4j-simple:1.7.12'
+    jmh 'org.slf4j:slf4j-simple:1.7.13'
   }
 
   jmh {

--- a/servo-aws/build.gradle
+++ b/servo-aws/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   compile project(':servo-core')
-  compile('com.amazonaws:aws-java-sdk-autoscaling:1.10.10')
-  compile('com.amazonaws:aws-java-sdk-cloudwatch:1.10.10')
+  compile('com.amazonaws:aws-java-sdk-autoscaling:1.10.38')
+  compile('com.amazonaws:aws-java-sdk-cloudwatch:1.10.38')
 }
 
 checkstyle {


### PR DESCRIPTION
Guava verions set to 18 to match the current version used
by platform internally.