### PR TITLE
iep-rxhttp:0.3.2

### DIFF
--- a/servo-atlas/build.gradle
+++ b/servo-atlas/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   compile project(':servo-core')
-  compile 'com.netflix.iep-shadow:iepshadow-rxnetty:0.4.13.12'
-  compile 'com.netflix.iep-shadow:iepshadow-iep-rxhttp:0.3.1.12'
+  compile 'com.netflix.iep-shadow:iepshadow-rxnetty:0.4.13.13'
+  compile 'com.netflix.iep-shadow:iepshadow-iep-rxhttp:0.3.2.13'
   compile "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jackson_version}"
   jmh project(':servo-core')


### PR DESCRIPTION
Update rxhttp version to fix NoSuchMethodError due
to reference to Spectator.config. Also fixes the
cleanup setting to work as expected with the injected
config.