### PR TITLE
Refactor synchronized block on JmxMonitorRegistry

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/jmx/JmxMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/jmx/JmxMonitorRegistry.java
@@ -127,6 +127,7 @@ public final class JmxMonitorRegistry implements MonitorRegistry {
       for (MonitorMBean bean : beans) {
         try {
           mBeanServer.unregisterMBean(bean.getObjectName());
+          locks.remove(bean.getObjectName());
         } catch (InstanceNotFoundException ignored) {
           // ignore errors attempting to unregister a non-registered monitor
           // a common error is to unregister twice

--- a/servo-core/src/main/java/com/netflix/servo/jmx/JmxMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/jmx/JmxMonitorRegistry.java
@@ -155,9 +155,6 @@ public final class JmxMonitorRegistry implements MonitorRegistry {
   }
 
   private Object getLock(ObjectName objectName) {
-    if (locks.get(objectName) == null) {
-      locks.putIfAbsent(objectName, new Object());
-    }
-    return locks.get(objectName);
+    return locks.computeIfAbsent(objectName, k -> new Object());
   }
 }


### PR DESCRIPTION
When profiling an application that registers objects in parallel the synchronization caused the operations to block. Refactored the synchronization block to lock on the ObjectName instead of the MBeanServer.