### PR TITLE
Handle unknown type tag values

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/publish/NormalizationTransform.java
+++ b/servo-core/src/main/java/com/netflix/servo/publish/NormalizationTransform.java
@@ -213,10 +213,8 @@ public final class NormalizationTransform implements MetricObserver {
           newMetrics.add(normalized);
         }
       } else if (!isInformational(dsType)) {
-        LOGGER.warn("NormalizationTransform should get only GAUGE and RATE metrics. "
-                + "Please use CounterToRateMetricTransform. "
-                + m.getConfig()
-        );
+        // unknown type - use a safe fallback
+        newMetrics.add(m); // we cannot normalize this
       }
     }
     observer.update(newMetrics);


### PR DESCRIPTION
Current behavior is to drop the metric completely if we cannot understand the 'type' tag. With this change we just leave the metric untouched.