### PR TITLE
fix bug: index out of bound in record StatsBuffer values

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/stats/StatsBuffer.java
+++ b/servo-core/src/main/java/com/netflix/servo/stats/StatsBuffer.java
@@ -93,7 +93,7 @@ public class StatsBuffer {
    * Record a new value for this buffer.
    */
   public void record(long n) {
-    values[count++ % size] = n;
+    values[(int) Long.remainderUnsigned(count++, size)] = n;
     total += n;
     sumSquares += n * n;
   }


### PR DESCRIPTION
while `count` in StatsBuffer overflow, the array index will be out of bound.

```
public void record(long n) {
    values[count++ % size] = n;
    total += n;
    sumSquares += n * n;
 }
```