### PR TITLE
Add counters for Errors to CloudWatchMetricObserver

### DIFF
--- a/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
+++ b/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
@@ -38,6 +38,7 @@ import com.netflix.servo.tag.BasicTag;
 import com.netflix.servo.tag.Tag;
 import com.netflix.servo.tag.TagList;
 import com.netflix.servo.util.Preconditions;
+import com.netflix.servo.util.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -209,6 +210,10 @@ public class CloudWatchMetricObserver extends BaseMetricObserver {
       final Tag error = new BasicTag("error", e.getClass().getSimpleName());
       DynamicCounter.increment(ERRORS_COUNTER_ID.withAdditionalTag(error));
       LOG.error("Error while submitting data for metrics : " + batch, e);
+    } catch (Error e) {
+      final Tag error = new BasicTag("error", e.getClass().getSimpleName());
+      DynamicCounter.increment(ERRORS_COUNTER_ID.withAdditionalTag(error));
+      throw Throwables.propagate(e);
     } finally {
       s.stop();
     }


### PR DESCRIPTION
This should let us catch errors such as NoSuchMethodError if/when AWS makes an incompatible API change