### PR TITLE
remove confusing apache stats

### DIFF
--- a/servo-apache/src/main/java/com/netflix/servo/publish/apache/ApacheStatusPoller.java
+++ b/servo-apache/src/main/java/com/netflix/servo/publish/apache/ApacheStatusPoller.java
@@ -102,7 +102,7 @@ public class ApacheStatusPoller extends BaseMetricPoller {
      * Metrics that should be included.
      */
     private static final Set<String> WHITELISTED_METRICS = UnmodifiableSet.of("Total_Accesses",
-        "Total_kBytes", "Uptime", "ReqPerSec", "BytesPerSec", "BytesPerReq",
+        "Total_kBytes", "Uptime",
         "BusyWorkers", "IdleWorkers",
         "ConnsTotal", "ConnsAsyncWriting",
         "ConnsAsyncKeepAlive", "ConnsAsyncClosing");

--- a/servo-apache/src/test/java/com/netflix/servo/publish/apache/ApacheStatusPollerTest.java
+++ b/servo-apache/src/test/java/com/netflix/servo/publish/apache/ApacheStatusPollerTest.java
@@ -96,12 +96,9 @@ public class ApacheStatusPollerTest {
     Metric uptime = counter("Uptime", UPTIME);
 
     List<Metric> counters = UnmodifiableList.of(accesses, kBytes, uptime);
-    Metric rps = gauge("ReqPerSec", RPS);
-    Metric bps = gauge("BytesPerSec", BPS);
-    Metric bpr = gauge("BytesPerReq", BPR);
     Metric busyWorkers = gauge("BusyWorkers", BUSY_WORKERS);
     Metric idleWorkers = gauge("IdleWorkers", IDLE_WORKERS);
-    List<Metric> gauges = UnmodifiableList.of(rps, bps, bpr, busyWorkers, idleWorkers);
+    List<Metric> gauges = UnmodifiableList.of(busyWorkers, idleWorkers);
 
     Metric waitingForConnection = scoreboard("WaitingForConnection", 45.0);
     Metric startingUp = scoreboard("StartingUp", 0.0);
@@ -168,12 +165,9 @@ public class ApacheStatusPollerTest {
     Metric uptime = counter("Uptime", UPTIME);
 
     List<Metric> counters = UnmodifiableList.of(accesses, kBytes, uptime);
-    Metric rps = gauge("ReqPerSec", RPS);
-    Metric bps = gauge("BytesPerSec", BPS);
-    Metric bpr = gauge("BytesPerReq", BPR);
     Metric busyWorkers = gauge("BusyWorkers", BUSY_WORKERS);
     Metric idleWorkers = gauge("IdleWorkers", IDLE_WORKERS);
-    List<Metric> gauges = UnmodifiableList.of(rps, bps, bpr, busyWorkers, idleWorkers);
+    List<Metric> gauges = UnmodifiableList.of(busyWorkers, idleWorkers);
 
     Metric waitingForConnection = scoreboard("WaitingForConnection", 45.0);
     Metric startingUp = scoreboard("StartingUp", 0.0);


### PR DESCRIPTION
This change removes: "ReqPerSec", "BytesPerSec",
and "BytesPerReq". These metrics are averaged over
the life of the process and create a confusion
when compared to other sources of RPS like the
"Total_Accesses" counter or the count statistic
on the log parsing timer.