### PR TITLE
Heavy metrics polling results in very frequent invocation of ValidCha…

### DIFF
--- a/servo-atlas/src/main/java/com/netflix/servo/publish/atlas/ValidCharacters.java
+++ b/servo-atlas/src/main/java/com/netflix/servo/publish/atlas/ValidCharacters.java
@@ -69,17 +69,21 @@ public final class ValidCharacters {
    * Convert a given string to one where all characters are valid.
    */
   public static String toValidCharset(String str) {
-    final int n = str.length();
-    final StringBuilder buf = new StringBuilder(n + 1);
-    for (int i = 0; i < n; i++) {
-      final char c = str.charAt(i);
-      if (c < CHARS_ALLOWED.length && CHARS_ALLOWED[c]) {
-        buf.append(c);
-      } else {
-        buf.append('_');
+    if (hasInvalidCharacters(str)) {
+      final int n = str.length();
+      final StringBuilder buf = new StringBuilder(n + 1);
+      for (int i = 0; i < n; i++) {
+        final char c = str.charAt(i);
+        if (c < CHARS_ALLOWED.length && CHARS_ALLOWED[c]) {
+          buf.append(c);
+        } else {
+          buf.append('_');
+        }
       }
+      return buf.toString();
+    } else {
+      return str;
     }
-    return buf.toString();
   }
 
   /**


### PR DESCRIPTION
…racters.toValidCharset, which, most of the time, unnecessarily allocates string copies, which creates measurable impact on garbage allocation (#2 StringBuilder abuser in the app I looked at, 100MB/min of char[] allocation).

Proposed change takes a tiny hit checking for invalid characters first before making a copy; I suspect that was the initial intention anyway.