### PR TITLE
Relax Atlas Validation rules for some group tags

### DIFF
--- a/servo-atlas/src/main/java/com/netflix/servo/publish/atlas/AtlasMetric.java
+++ b/servo-atlas/src/main/java/com/netflix/servo/publish/atlas/AtlasMetric.java
@@ -79,7 +79,7 @@ class AtlasMetric implements JsonPayload {
     gen.writeObjectFieldStart("tags");
     gen.writeStringField("name", config.getName());
     for (Tag tag : config.getTags()) {
-      gen.writeStringField(tag.getKey(), tag.getValue());
+      ValidCharacters.tagToJson(gen, tag);
     }
     gen.writeEndObject();
 

--- a/servo-atlas/src/main/java/com/netflix/servo/publish/atlas/UpdateRequest.java
+++ b/servo-atlas/src/main/java/com/netflix/servo/publish/atlas/UpdateRequest.java
@@ -93,9 +93,7 @@ public final class UpdateRequest implements JsonPayload {
     // common tags
     gen.writeObjectFieldStart("tags");
     for (Tag tag : tags) {
-      gen.writeStringField(
-          ValidCharacters.toValidCharset(tag.getKey()),
-          ValidCharacters.toValidCharset(tag.getValue()));
+      ValidCharacters.tagToJson(gen, tag);
     }
     gen.writeEndObject();
 

--- a/servo-atlas/src/test/java/com/netflix/servo/publish/atlas/ValidCharactersTest.java
+++ b/servo-atlas/src/test/java/com/netflix/servo/publish/atlas/ValidCharactersTest.java
@@ -15,7 +15,17 @@
  */
 package com.netflix.servo.publish.atlas;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.netflix.servo.Metric;
+import com.netflix.servo.monitor.MonitorConfig;
+import com.netflix.servo.tag.BasicTag;
+import com.netflix.servo.tag.BasicTagList;
+import com.netflix.servo.tag.Tag;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -30,8 +40,8 @@ public class ValidCharactersTest {
 
   @Test
   public void testInvalidStrIsFixed() throws Exception {
-    String str = "Aabc09.-_ abc";
-    assertEquals(ValidCharacters.toValidCharset(str), "Aabc09.-__abc");
+    String str = "Aabc09.-~^_ abc";
+    assertEquals(ValidCharacters.toValidCharset(str), "Aabc09.-____abc");
 
     String boundaries = "\u0000\u0128\uffff";
     assertEquals(ValidCharacters.toValidCharset(boundaries), "___");
@@ -45,10 +55,60 @@ public class ValidCharactersTest {
 
   @Test
   public void testInvalidStr() throws Exception {
+    String caret = "abc09.-_^abc";
+    assertTrue(ValidCharacters.hasInvalidCharacters(caret));
+
+    String tilde = "abc09.-_~abc";
+    assertTrue(ValidCharacters.hasInvalidCharacters(tilde));
+
     String str = "abc09.-_ abc";
     assertTrue(ValidCharacters.hasInvalidCharacters(str));
 
     String boundaries = "\u0000\u0128\uffff";
     assertTrue(ValidCharacters.hasInvalidCharacters(boundaries));
+  }
+
+  @Test
+  public void testValidValue() throws Exception {
+    MonitorConfig cfg = MonitorConfig.builder("foo^bar")
+        .withTag("nf.asg", "foo~1")
+        .withTag("nf.cluster", "foo^1.0")
+        .withTag("key^1.0", "val~1.0")
+        .build();
+    Metric metric = new Metric(cfg, 0, 0.0);
+    Metric fixed = ValidCharacters.toValidValue(metric);
+    Metric expected = new Metric("foo_bar",
+        BasicTagList.of("nf.asg", "foo~1", "nf.cluster", "foo^1.0", "key_1.0", "val_1.0"), 0, 0.0);
+    assertEquals(fixed, expected);
+  }
+
+  private static JsonFactory factory = new JsonFactory();
+  static {
+    factory.enable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+  }
+
+  private static String toJson(Tag tag) throws IOException {
+    StringWriter writer = new StringWriter();
+    JsonGenerator generator = factory.createGenerator(writer);
+    generator.writeStartObject();
+    ValidCharacters.tagToJson(generator, tag);
+    generator.writeEndObject();
+    generator.close();
+    return writer.toString();
+  }
+
+  @Test
+  public void testTagToJson() throws Exception {
+    Tag valid = new BasicTag("key", "value");
+    assertEquals(toJson(valid), "{\"key\":\"value\"}");
+
+    Tag invalidKey = new BasicTag("key~^a", "value");
+    assertEquals(toJson(invalidKey), "{\"key__a\":\"value\"}");
+
+    Tag invalidValue = new BasicTag("key", "value~^ 1");
+    assertEquals(toJson(invalidValue), "{\"key\":\"value___1\"}");
+
+    Tag relaxedValue = new BasicTag("nf.asg", "value~^ 1");
+    assertEquals(toJson(relaxedValue), "{\"nf.asg\":\"value~^_1\"}");
   }
 }


### PR DESCRIPTION
Allows '^' and '~' as values for nf.asg and nf.cluster, but still
rejects them for other tags.