### PR TITLE
fix #410, log AmazonServiceException

### DIFF
--- a/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
+++ b/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
@@ -205,6 +205,7 @@ public class CloudWatchMetricObserver extends BaseMetricObserver {
     } catch (AmazonServiceException e) {
       final Tag error = new BasicTag("error", e.getErrorCode());
       DynamicCounter.increment(ERRORS_COUNTER_ID.withAdditionalTag(error));
+      LOG.error("Error while submitting data for metrics : " + batch, e);
     } catch (Exception e) {
       final Tag error = new BasicTag("error", e.getClass().getSimpleName());
       DynamicCounter.increment(ERRORS_COUNTER_ID.withAdditionalTag(error));


### PR DESCRIPTION
Logs AmazonServiceException just like other exceptions
when publishing cloudwatch data. Helps make debugging
easier if the publish is failing due to bad or expired
credentials.