### PR TITLE
variance and standard deviation are imprecise when size is not high

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/stats/StatsBuffer.java
+++ b/servo-core/src/main/java/com/netflix/servo/stats/StatsBuffer.java
@@ -122,7 +122,11 @@ public class StatsBuffer {
       sumSquares += values[i] * values[i];
     }
     mean = (double) total / curSize;
-    variance = (sumSquares / curSize) - (mean * mean);
+    if (curSize == 1) {
+      variance = 0d;
+    } else {
+      variance = (sumSquares - ((double) total * total / curSize)) / (curSize - 1);
+    }
     stddev = Math.sqrt(variance);
 
     computePercentiles(curSize);

--- a/servo-core/src/test/java/com/netflix/servo/stats/StatsBufferTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/stats/StatsBufferTest.java
@@ -72,13 +72,13 @@ public class StatsBufferTest {
   @Test
   public void testVarianceNoWrap() {
     StatsBuffer buffer = getNoWrap();
-    assertEquals(buffer.getVariance(), 20916.66667, 1e-4);
+    assertEquals(buffer.getVariance(), 20958.5, 1e-4);
   }
 
   @Test
   public void testStdDevNoWrap() {
     StatsBuffer buffer = getNoWrap();
-    assertEquals(buffer.getStdDev(), 144.62595, 1e-4);
+    assertEquals(buffer.getStdDev(), 144.77051, 1e-4);
   }
 
   @Test
@@ -173,7 +173,7 @@ public class StatsBufferTest {
     assertEquals(buffer.getMean(), (double) EXPECTED_TOTAL_WRAP / SIZE);
   }
 
-  static final double EXPECTED_VARIANCE_WRAP = 83333.25;
+  static final double EXPECTED_VARIANCE_WRAP = 83416.66667;
 
   @Test
   public void testVarianceWrap() {


### PR DESCRIPTION
In my opinion the current variance (and by consequence the standard deviation) computation is imprecise, when curSize is not high (when curSize < 10 for example):
```java
    variance = (sumSquares / curSize) - (mean * mean);
```
The computation I suggest in this pull request does not hurt and is precise:
```java
    if (curSize == 1) {
      variance = 0d;
    } else {
      variance = (sumSquares - ((double) total * total / curSize)) / (curSize - 1);
    }
```
For reference:
http://web.archive.org/web/20050512031826/http://helios.bto.ed.ac.uk/bto/statistics/tress3.html