### PR TITLE
use localhost explicitly for graphite test

### DIFF
--- a/servo-graphite/src/test/java/com/netflix/servo/publish/graphite/GraphiteMetricObserverTest.java
+++ b/servo-graphite/src/test/java/com/netflix/servo/publish/graphite/GraphiteMetricObserverTest.java
@@ -30,7 +30,7 @@ import static org.testng.Assert.assertEquals;
 
 public class GraphiteMetricObserverTest {
   private String getLocalHostIp() throws UnknownHostException {
-    return InetAddress.getLocalHost().getHostAddress();
+    return "127.0.0.1";
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
In many cases the ip used before would not allow access
in causing the connections to timeout.