### PR TITLE
Upgrade pmd to 5.6.1 to avoid NPE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ subprojects {
   }
 
   pmd {
-    toolVersion = '5.5.4'
+    toolVersion = '5.6.1'
     ignoreFailures = false
     ruleSets = []
     ruleSetFiles = rootProject.files("codequality/pmd.xml")


### PR DESCRIPTION
With the pmd version 5.5.4 we're now getting:

```
Exception applying rule InvalidSlf4jMessageFormat on file servo/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java, continuing with next rule
java.lang.NullPointerException
```