### PR TITLE
427 Make sure MonitorRegistryMetricPoller converts booleans into numerical values

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/publish/JmxMetricPoller.java
+++ b/servo-core/src/main/java/com/netflix/servo/publish/JmxMetricPoller.java
@@ -150,7 +150,7 @@ public final class JmxMetricPoller implements MetricPoller {
       Object value) {
     long now = System.currentTimeMillis();
     if (onlyNumericMetrics) {
-      value = asNumber(value);
+      value = MetricPoller.asNumber(value);
     }
     if (value != null) {
 
@@ -245,23 +245,6 @@ public final class JmxMetricPoller implements MetricPoller {
         addMetric(metrics, attrName, newTags, e.getValue());
       }
     }
-  }
-
-  /**
-   * Try to convert an object into a number. Boolean values will return 1 if
-   * true and 0 if false. If the value is null or an unknown data type null
-   * will be returned.
-   */
-  private static Number asNumber(Object value) {
-    Number num = null;
-    if (value == null) {
-      num = null;
-    } else if (value instanceof Number) {
-      num = (Number) value;
-    } else if (value instanceof Boolean) {
-      num = ((Boolean) value) ? 1 : 0;
-    }
-    return num;
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/publish/MetricPoller.java
+++ b/servo-core/src/main/java/com/netflix/servo/publish/MetricPoller.java
@@ -46,4 +46,21 @@ public interface MetricPoller {
    * @return list of current metric values
    */
   List<Metric> poll(MetricFilter filter, boolean reset);
+
+  /**
+   * Try to convert an object into a number. Boolean values will return 1 if
+   * true and 0 if false. If the value is null or an unknown data type null
+   * will be returned.
+   */
+  static Number asNumber(Object value) {
+    Number num = null;
+    if (value == null) {
+      num = null;
+    } else if (value instanceof Number) {
+      num = (Number) value;
+    } else if (value instanceof Boolean) {
+      num = ((Boolean) value) ? 1 : 0;
+    }
+    return num;
+  }
 }


### PR DESCRIPTION
Not sure if it is pointing to the right branch. I based it on version 2.12.14 because I use an older version of aws-sdk.