### PR TITLE
Hooks to dump the JSON payload sent to atlas

### DIFF
--- a/servo-atlas/src/main/java/com/netflix/servo/publish/atlas/AtlasPrettyPrinter.java
+++ b/servo-atlas/src/main/java/com/netflix/servo/publish/atlas/AtlasPrettyPrinter.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2017 Netflix, Inc.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo.publish.atlas;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.PrettyPrinter;
+
+import java.io.IOException;
+
+/**
+ * A simple Jackson Pretty Printer that helps dump atlas payloads in a format that is easy to grep.
+ */
+class AtlasPrettyPrinter implements PrettyPrinter {
+  private int nesting = 0;
+
+  @Override
+  public void writeRootValueSeparator(JsonGenerator jg) throws IOException {
+  }
+
+  @Override
+  public void writeStartObject(JsonGenerator gen) throws IOException {
+    gen.writeRaw('{');
+    if (nesting == 0) {
+      gen.writeRaw('\n');
+    }
+    ++nesting;
+  }
+
+  @Override
+  public void writeEndObject(JsonGenerator gen, int nrOfEntries) throws IOException {
+    --nesting;
+    gen.writeRaw('}');
+  }
+
+  @Override
+  public void writeObjectEntrySeparator(JsonGenerator gen) throws IOException {
+    gen.writeRaw(',');
+    if (nesting <= 1) {
+      gen.writeRaw('\n');
+    }
+  }
+
+  @Override
+  public void writeObjectFieldValueSeparator(JsonGenerator gen) throws IOException {
+    gen.writeRaw(':');
+  }
+
+  @Override
+  public void writeStartArray(JsonGenerator gen) throws IOException {
+    gen.writeRaw("[\n");
+  }
+
+  @Override
+  public void writeEndArray(JsonGenerator gen, int nrOfValues) throws IOException {
+    gen.writeRaw("]\n");
+  }
+
+  @Override
+  public void writeArrayValueSeparator(JsonGenerator gen) throws IOException {
+    gen.writeRaw(',');
+    if (nesting == 1) {
+      gen.writeRaw('\n');
+    }
+  }
+
+  @Override
+  public void beforeArrayValues(JsonGenerator gen) throws IOException {
+  }
+
+  @Override
+  public void beforeObjectEntries(JsonGenerator gen) throws IOException {
+  }
+}

--- a/servo-atlas/src/test/java/com/netflix/servo/publish/atlas/AtlasPrettyPrinterTest.java
+++ b/servo-atlas/src/test/java/com/netflix/servo/publish/atlas/AtlasPrettyPrinterTest.java
@@ -1,0 +1,39 @@
+package com.netflix.servo.publish.atlas;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.netflix.servo.Metric;
+import com.netflix.servo.tag.BasicTagList;
+import com.netflix.servo.tag.TagList;
+import org.testng.annotations.Test;
+
+import java.io.StringWriter;
+
+import static org.testng.Assert.assertEquals;
+
+public class AtlasPrettyPrinterTest {
+
+  @Test
+  public void testPayload() throws Exception {
+    TagList commonTags = BasicTagList.of("nf.app", "example", "nf.cluster", "example-main", "nf.region", "us-west-3");
+    Metric m1 = new Metric("foo1", BasicTagList.of("id", "ab"), 1000L, 1.0);
+    Metric m2 = new Metric("foo2", BasicTagList.of("id", "bc", "class", "klz"), 1000L, 2.0);
+    Metric m3 = new Metric("foo3", BasicTagList.EMPTY, 1000L, 3.0);
+    Metric[] metrics = new Metric[] {m1, m2, m3};
+    JsonPayload update = new UpdateRequest(commonTags, metrics, metrics.length);
+    JsonFactory factory = new JsonFactory();
+    StringWriter writer = new StringWriter();
+    JsonGenerator generator = factory.createGenerator(writer);
+    generator.setPrettyPrinter(new AtlasPrettyPrinter());
+    update.toJson(generator);
+    generator.close();
+    writer.close();
+    String expected = "{\n\"tags\":{\"nf.app\":\"example\",\"nf.cluster\":\"example-main\",\"nf.region\":\"us-west-3\"},\n\"metrics\":[\n" +
+        "{\"tags\":{\"name\":\"foo1\",\"id\":\"ab\"},\"start\":1000,\"value\":1.0},\n" +
+        "{\"tags\":{\"name\":\"foo2\",\"class\":\"klz\",\"id\":\"bc\"},\"start\":1000,\"value\":2.0},\n" +
+        "{\"tags\":{\"name\":\"foo3\"},\"start\":1000,\"value\":3.0}]\n" +
+        "}";
+
+    assertEquals(writer.toString(), expected);
+  }
+}


### PR DESCRIPTION
Add hooks to be able to dump the JSON payload sent to atlas backends.
This is a bit more useful to debug certain use cases than
`FileMetricsObserver`