### PR TITLE
Add timeout exception counter to the registry

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/publish/MonitorRegistryMetricPoller.java
+++ b/servo-core/src/main/java/com/netflix/servo/publish/MonitorRegistryMetricPoller.java
@@ -19,7 +19,9 @@ import com.netflix.servo.DefaultMonitorRegistry;
 import com.netflix.servo.Metric;
 import com.netflix.servo.MonitorRegistry;
 import com.netflix.servo.monitor.CompositeMonitor;
+import com.netflix.servo.monitor.Counter;
 import com.netflix.servo.monitor.Monitor;
+import com.netflix.servo.monitor.Monitors;
 import com.netflix.servo.util.Clock;
 import com.netflix.servo.util.ClockWithOffset;
 import com.netflix.servo.util.ThreadFactories;
@@ -44,6 +46,10 @@ import java.util.concurrent.atomic.AtomicReference;
 public final class MonitorRegistryMetricPoller implements MetricPoller {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MonitorRegistryMetricPoller.class);
+  private static final Counter TIMEOUT_ERRORS = Monitors.newCounter("servo.getValueTimeout");
+  static {
+    DefaultMonitorRegistry.getInstance().register(TIMEOUT_ERRORS);
+  }
 
   private final MonitorRegistry registry;
 
@@ -138,6 +144,7 @@ public final class MonitorRegistryMetricPoller implements MetricPoller {
       }
     } catch (TimeLimiter.UncheckedTimeoutException e) {
       LOGGER.warn("timeout trying to get value for {}", monitor.getConfig());
+      TIMEOUT_ERRORS.increment();
     } catch (Exception e) {
       LOGGER.warn("failed to get value for " + monitor.getConfig(), e);
     }

--- a/servo-core/src/main/java/com/netflix/servo/publish/MonitorRegistryMetricPoller.java
+++ b/servo-core/src/main/java/com/netflix/servo/publish/MonitorRegistryMetricPoller.java
@@ -18,10 +18,12 @@ package com.netflix.servo.publish;
 import com.netflix.servo.DefaultMonitorRegistry;
 import com.netflix.servo.Metric;
 import com.netflix.servo.MonitorRegistry;
+import com.netflix.servo.monitor.BasicCounter;
 import com.netflix.servo.monitor.CompositeMonitor;
 import com.netflix.servo.monitor.Counter;
+import com.netflix.servo.monitor.DynamicCounter;
 import com.netflix.servo.monitor.Monitor;
-import com.netflix.servo.monitor.Monitors;
+import com.netflix.servo.monitor.MonitorConfig;
 import com.netflix.servo.util.Clock;
 import com.netflix.servo.util.ClockWithOffset;
 import com.netflix.servo.util.ThreadFactories;
@@ -46,9 +48,11 @@ import java.util.concurrent.atomic.AtomicReference;
 public final class MonitorRegistryMetricPoller implements MetricPoller {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MonitorRegistryMetricPoller.class);
-  private static final Counter TIMEOUT_ERRORS = Monitors.newCounter("servo.getValueTimeout");
+  private static final String GET_VALUE_ERROR = "servo.getValueError";
+  private static final Counter TIMEOUT_ERROR = new BasicCounter(MonitorConfig.builder(GET_VALUE_ERROR)
+      .withTag("id", "timeout").build());
   static {
-    DefaultMonitorRegistry.getInstance().register(TIMEOUT_ERRORS);
+    DefaultMonitorRegistry.getInstance().register(TIMEOUT_ERROR);
   }
 
   private final MonitorRegistry registry;
@@ -144,9 +148,10 @@ public final class MonitorRegistryMetricPoller implements MetricPoller {
       }
     } catch (TimeLimiter.UncheckedTimeoutException e) {
       LOGGER.warn("timeout trying to get value for {}", monitor.getConfig());
-      TIMEOUT_ERRORS.increment();
+      TIMEOUT_ERROR.increment();
     } catch (Exception e) {
       LOGGER.warn("failed to get value for " + monitor.getConfig(), e);
+      DynamicCounter.increment(GET_VALUE_ERROR, "id", e.getClass().getSimpleName());
     }
     return null;
   }


### PR DESCRIPTION
Count the number of times we triggered a timeout exception getting the
value of a monitor.