### PR TITLE
add Automatic-Module-Name to manifest

### DIFF
--- a/servo-apache/build.gradle
+++ b/servo-apache/build.gradle
@@ -1,3 +1,11 @@
 dependencies {
   compile project(':servo-core')
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.servo.apache"
+    )
+  }
+}

--- a/servo-atlas/build.gradle
+++ b/servo-atlas/build.gradle
@@ -7,3 +7,11 @@ dependencies {
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-smile"
   jmh project(':servo-core')
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.servo.atlas"
+    )
+  }
+}

--- a/servo-aws/build.gradle
+++ b/servo-aws/build.gradle
@@ -7,3 +7,11 @@ dependencies {
 checkstyle {
   sourceSets = []
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.servo.aws"
+    )
+  }
+}

--- a/servo-core/build.gradle
+++ b/servo-core/build.gradle
@@ -17,3 +17,10 @@ pmd {
   ignoreFailures = true
 }
 
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.servo.core"
+    )
+  }
+}

--- a/servo-example/build.gradle
+++ b/servo-example/build.gradle
@@ -27,3 +27,11 @@ task(runWithAtlas, dependsOn: 'classes', type: JavaExec) {
 checkstyle {
   sourceSets = []
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.servo.example"
+    )
+  }
+}

--- a/servo-graphite/build.gradle
+++ b/servo-graphite/build.gradle
@@ -1,3 +1,11 @@
 dependencies {
   compile project(':servo-core')
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.servo.graphite"
+    )
+  }
+}

--- a/servo-tomcat/build.gradle
+++ b/servo-tomcat/build.gradle
@@ -1,3 +1,11 @@
 dependencies {
   compile project(':servo-core')
 }
+
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.netflix.servo.tomcat"
+    )
+  }
+}


### PR DESCRIPTION
Should help avoid compatibility problems in the future
if users try to pull these in before we support a proper
`module-info.java`. For more details see:

http://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html