### PR TITLE
getting indiv props instead of reading all props

### DIFF
--- a/servo-aws/src/main/java/com/netflix/servo/tag/aws/AwsInjectableTag.java
+++ b/servo-aws/src/main/java/com/netflix/servo/tag/aws/AwsInjectableTag.java
@@ -89,7 +89,7 @@ public enum AwsInjectableTag implements Tag {
 
   static String getAutoScaleGroup() {
     try {
-      String credFileProperty = System.getProperties().getProperty(
+      String credFileProperty = System.getProperty(
           AwsPropertyKeys.AWS_CREDENTIALS_FILE.getBundle());
       AWSCredentials credentials;
 

--- a/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
@@ -122,7 +122,6 @@ public final class DefaultMonitorRegistry implements MonitorRegistry {
   private static Properties loadProps() {
     String registryClassProp = System.getProperty(REGISTRY_CLASS_PROP);
     String registryNameProp = System.getProperty(REGISTRY_NAME_PROP);
-    String defaultRegistryName = System.getProperty(DEFAULT_REGISTRY_NAME);
     String registryJmxNameProp = System.getProperty(REGISTRY_JMX_NAME_PROP);
     
     Properties props = new Properties();
@@ -131,9 +130,6 @@ public final class DefaultMonitorRegistry implements MonitorRegistry {
     }
     if (registryNameProp != null) {
       props.setProperty(REGISTRY_NAME_PROP, registryNameProp);
-    }
-    if (defaultRegistryName != null) {
-      props.setProperty(DEFAULT_REGISTRY_NAME, defaultRegistryName);
     }
     if (registryJmxNameProp != null) {
       props.setProperty(REGISTRY_JMX_NAME_PROP, registryJmxNameProp);

--- a/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
@@ -61,7 +61,7 @@ public final class DefaultMonitorRegistry implements MonitorRegistry {
    * Creates a new instance based on system properties.
    */
   DefaultMonitorRegistry() {
-    this(System.getProperties());
+    this(loadProps());
   }
 
   /**
@@ -117,6 +117,23 @@ public final class DefaultMonitorRegistry implements MonitorRegistry {
     }
 
     return mapper;
+  }
+  
+  private static Properties loadProps() {
+    Properties props = new Properties();
+    if(System.getProperty(REGISTRY_CLASS_PROP) != null) {
+      props.setProperty(REGISTRY_CLASS_PROP, System.getProperty(REGISTRY_CLASS_PROP));
+    }
+    if(System.getProperty(REGISTRY_NAME_PROP) != null) {
+      props.setProperty(REGISTRY_NAME_PROP, System.getProperty(REGISTRY_NAME_PROP));
+    }
+    if(System.getProperty(DEFAULT_REGISTRY_NAME) != null) {
+      props.setProperty(DEFAULT_REGISTRY_NAME, System.getProperty(DEFAULT_REGISTRY_NAME));
+    }
+    if(System.getProperty(REGISTRY_JMX_NAME_PROP) != null) {
+      props.setProperty(REGISTRY_JMX_NAME_PROP, System.getProperty(REGISTRY_JMX_NAME_PROP));
+    }
+    return props;
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
@@ -120,18 +120,23 @@ public final class DefaultMonitorRegistry implements MonitorRegistry {
   }
   
   private static Properties loadProps() {
+    String registryClassProp = System.getProperty(REGISTRY_CLASS_PROP);
+    String registryNameProp = System.getProperty(REGISTRY_NAME_PROP);
+    String defaultRegistryName = System.getProperty(DEFAULT_REGISTRY_NAME);
+    String registryJmxNameProp = System.getProperty(REGISTRY_JMX_NAME_PROP);
+    
     Properties props = new Properties();
-    if (System.getProperty(REGISTRY_CLASS_PROP) != null) {
-      props.setProperty(REGISTRY_CLASS_PROP, System.getProperty(REGISTRY_CLASS_PROP));
+    if (registryClassProp != null) {
+      props.setProperty(REGISTRY_CLASS_PROP, registryClassProp);
     }
-    if (System.getProperty(REGISTRY_NAME_PROP) != null) {
-      props.setProperty(REGISTRY_NAME_PROP, System.getProperty(REGISTRY_NAME_PROP));
+    if (registryNameProp != null) {
+      props.setProperty(REGISTRY_NAME_PROP, registryNameProp);
     }
-    if (System.getProperty(DEFAULT_REGISTRY_NAME) != null) {
-      props.setProperty(DEFAULT_REGISTRY_NAME, System.getProperty(DEFAULT_REGISTRY_NAME));
+    if (defaultRegistryName != null) {
+      props.setProperty(DEFAULT_REGISTRY_NAME, defaultRegistryName);
     }
-    if (System.getProperty(REGISTRY_JMX_NAME_PROP) != null) {
-      props.setProperty(REGISTRY_JMX_NAME_PROP, System.getProperty(REGISTRY_JMX_NAME_PROP));
+    if (registryJmxNameProp != null) {
+      props.setProperty(REGISTRY_JMX_NAME_PROP, registryJmxNameProp);
     }
     return props;
   }

--- a/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
@@ -121,16 +121,16 @@ public final class DefaultMonitorRegistry implements MonitorRegistry {
   
   private static Properties loadProps() {
     Properties props = new Properties();
-    if(System.getProperty(REGISTRY_CLASS_PROP) != null) {
+    if (System.getProperty(REGISTRY_CLASS_PROP) != null) {
       props.setProperty(REGISTRY_CLASS_PROP, System.getProperty(REGISTRY_CLASS_PROP));
     }
-    if(System.getProperty(REGISTRY_NAME_PROP) != null) {
+    if (System.getProperty(REGISTRY_NAME_PROP) != null) {
       props.setProperty(REGISTRY_NAME_PROP, System.getProperty(REGISTRY_NAME_PROP));
     }
-    if(System.getProperty(DEFAULT_REGISTRY_NAME) != null) {
+    if (System.getProperty(DEFAULT_REGISTRY_NAME) != null) {
       props.setProperty(DEFAULT_REGISTRY_NAME, System.getProperty(DEFAULT_REGISTRY_NAME));
     }
-    if(System.getProperty(REGISTRY_JMX_NAME_PROP) != null) {
+    if (System.getProperty(REGISTRY_JMX_NAME_PROP) != null) {
       props.setProperty(REGISTRY_JMX_NAME_PROP, System.getProperty(REGISTRY_JMX_NAME_PROP));
     }
     return props;


### PR DESCRIPTION
Most of the secured applications are not given access to all system properties on server. Making this change to prevent reading all the system properties and just read the properties that are required for creating DefaultMonitorRegistry instance.