### PR TITLE
add support to delegate to spectator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ subprojects {
   dependencies {
     compile 'org.slf4j:slf4j-api'
     compile 'com.google.guava:guava'
+    compile 'com.netflix.spectator:spectator-api:0.66.0'
     testCompile 'org.testng:testng:6.1.1'
     testRuntime 'org.slf4j:slf4j-log4j12'
     testRuntime 'log4j:log4j:1.2.17'

--- a/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
@@ -123,7 +123,7 @@ public final class DefaultMonitorRegistry implements MonitorRegistry {
     String registryClassProp = System.getProperty(REGISTRY_CLASS_PROP);
     String registryNameProp = System.getProperty(REGISTRY_NAME_PROP);
     String registryJmxNameProp = System.getProperty(REGISTRY_JMX_NAME_PROP);
-    
+
     Properties props = new Properties();
     if (registryClassProp != null) {
       props.setProperty(REGISTRY_CLASS_PROP, registryClassProp);

--- a/servo-core/src/main/java/com/netflix/servo/SpectatorContext.java
+++ b/servo-core/src/main/java/com/netflix/servo/SpectatorContext.java
@@ -1,0 +1,91 @@
+package com.netflix.servo;
+
+import com.netflix.servo.monitor.MonitorConfig;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DistributionSummary;
+import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.api.patterns.PolledMeter;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Helper that can be used to delegate to spectator. Other than calling
+ * {@link #setRegistry(Registry)} to set the registry to use, it is only intended for use
+ * within servo.
+ */
+public final class SpectatorContext {
+
+  private static final ScheduledExecutorService GAUGE_POOL = Executors.newScheduledThreadPool(
+      2,
+      task -> {
+        Thread t = new Thread(task, "servo-gauge-poller");
+        t.setDaemon(true);
+        return t;
+      }
+  );
+
+  private static volatile Registry registry = new NoopRegistry();
+
+  /**
+   * Set the registry to use. By default it will use the NoopRegistry.
+   */
+  public static void setRegistry(Registry registry) {
+    SpectatorContext.registry = registry;
+  }
+
+  /**
+   * Get the registry that was configured.
+   */
+  public static Registry getRegistry() {
+    return registry;
+  }
+
+  /** Create a gauge based on the config. */
+  public static Gauge gauge(MonitorConfig config) {
+    return registry.gauge(createId(config));
+  }
+
+  /** Create a max gauge based on the config. */
+  public static Gauge maxGauge(MonitorConfig config) {
+    return registry.maxGauge(createId(config));
+  }
+
+  /** Create a counter based on the config. */
+  public static Counter counter(MonitorConfig config) {
+    return registry.counter(createId(config));
+  }
+
+  /** Create a timer based on the config. */
+  public static Timer timer(MonitorConfig config) {
+    return registry.timer(createId(config));
+  }
+
+  /** Create a distribution summary based on the config. */
+  public static DistributionSummary distributionSummary(MonitorConfig config) {
+    return registry.distributionSummary(createId(config));
+  }
+
+  /** Convert servo config to spectator id. */
+  public static Id createId(MonitorConfig config) {
+    return registry
+        .createId(config.getName())
+        .withTags(config.getTags().asMap());
+  }
+
+  /** Dedicated thread pool for polling user defined functions registered as gauges. */
+  public static ScheduledExecutorService gaugePool() {
+    return GAUGE_POOL;
+  }
+
+  /** Create builder for a polled gauge based on the config. */
+  public static PolledMeter.Builder polledGauge(MonitorConfig config) {
+    return PolledMeter.using(registry)
+        .withId(createId(config))
+        .scheduleOn(GAUGE_POOL);
+  }
+}

--- a/servo-core/src/main/java/com/netflix/servo/monitor/AnnotatedNumberMonitor.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/AnnotatedNumberMonitor.java
@@ -15,7 +15,9 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.util.Throwables;
+import com.netflix.spectator.api.patterns.PolledMeter;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
@@ -33,6 +35,13 @@ class AnnotatedNumberMonitor extends AbstractMonitor<Number> implements NumericM
     super(config);
     this.object = object;
     this.field = field;
+    if ("COUNTER".equals(config.getTags().getValue("type"))) {
+      SpectatorContext.polledGauge(config)
+          .monitorMonotonicCounter(this, m -> m.getValue(0).longValue());
+    } else {
+      SpectatorContext.polledGauge(config)
+          .monitorValue(this, m -> m.getValue(0).doubleValue());
+    }
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/BasicCounter.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/BasicCounter.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.annotations.DataSourceType;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -26,12 +27,14 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class BasicCounter extends AbstractMonitor<Number> implements Counter {
   private final AtomicLong count = new AtomicLong();
+  private final com.netflix.spectator.api.Counter spectatorCounter;
 
   /**
    * Creates a new instance of the counter.
    */
   public BasicCounter(MonitorConfig config) {
     super(config.withAdditionalTag(DataSourceType.COUNTER));
+    spectatorCounter = SpectatorContext.counter(config);
   }
 
   /**
@@ -39,6 +42,7 @@ public final class BasicCounter extends AbstractMonitor<Number> implements Count
    */
   @Override
   public void increment() {
+    spectatorCounter.increment();
     count.incrementAndGet();
   }
 
@@ -47,6 +51,7 @@ public final class BasicCounter extends AbstractMonitor<Number> implements Count
    */
   @Override
   public void increment(long amount) {
+    spectatorCounter.increment(amount);
     count.getAndAdd(amount);
   }
 

--- a/servo-core/src/main/java/com/netflix/servo/monitor/BasicGauge.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/BasicGauge.java
@@ -15,8 +15,10 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.util.Throwables;
+import com.netflix.spectator.api.patterns.PolledMeter;
 
 import java.util.concurrent.Callable;
 
@@ -35,6 +37,8 @@ public final class BasicGauge<T extends Number> extends AbstractMonitor<T> imple
   public BasicGauge(MonitorConfig config, Callable<T> function) {
     super(config.withAdditionalTag(DataSourceType.GAUGE));
     this.function = function;
+    SpectatorContext.polledGauge(config)
+        .monitorValue(this, m -> m.getValue(0).doubleValue());
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/DoubleCounter.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/DoubleCounter.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.util.Clock;
 import com.netflix.servo.util.VisibleForTesting;
@@ -30,6 +31,7 @@ import java.util.concurrent.atomic.AtomicLong;
 class DoubleCounter extends AbstractMonitor<Number> implements NumericMonitor<Number> {
 
   private final StepLong count;
+  private final com.netflix.spectator.api.Counter spectatorCounter;
 
   /**
    * Creates a new instance of the counter.
@@ -40,6 +42,7 @@ class DoubleCounter extends AbstractMonitor<Number> implements NumericMonitor<Nu
     // the publishing pipeline receiving the value.
     super(config.withAdditionalTag(DataSourceType.NORMALIZED));
     count = new StepLong(0L, clock);
+    spectatorCounter = SpectatorContext.counter(config);
   }
 
   private void add(AtomicLong num, double amount) {
@@ -57,6 +60,7 @@ class DoubleCounter extends AbstractMonitor<Number> implements NumericMonitor<Nu
    * Increment the value by the specified amount.
    */
   void increment(double amount) {
+    spectatorCounter.add(amount);
     if (amount >= 0.0) {
       for (int i = 0; i < Pollers.NUM_POLLERS; ++i) {
         add(count.getCurrent(i), amount);

--- a/servo-core/src/main/java/com/netflix/servo/monitor/DoubleGauge.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/DoubleGauge.java
@@ -16,12 +16,14 @@
 package com.netflix.servo.monitor;
 
 import com.google.common.util.concurrent.AtomicDouble;
+import com.netflix.servo.SpectatorContext;
 
 /**
  * A {@link Gauge} that reports a double value.
  */
 public class DoubleGauge extends NumberGauge {
   private final AtomicDouble number;
+  private final com.netflix.spectator.api.Gauge spectatorGauge;
 
   /**
    * Create a new instance with the specified configuration.
@@ -32,12 +34,14 @@ public class DoubleGauge extends NumberGauge {
     super(config);
     number = new AtomicDouble(0.0);
     setBackingNumber(number);
+    spectatorGauge = SpectatorContext.gauge(config);
   }
 
   /**
    * Set the current value.
    */
   public void set(Double n) {
+    spectatorGauge.set(n);
     number.set(n);
   }
 

--- a/servo-core/src/main/java/com/netflix/servo/monitor/DoubleMaxGauge.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/DoubleMaxGauge.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2013 Netflix, Inc.
+/*
+ * Copyright 2011-2018 Netflix, Inc.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,35 +26,35 @@ import java.util.concurrent.atomic.AtomicLong;
  * Gauge that keeps track of the maximum value seen since the last reset. Updates should be
  * non-negative, the reset value is 0.
  */
-public class MaxGauge extends AbstractMonitor<Long>
-    implements Gauge<Long> {
+public class DoubleMaxGauge extends AbstractMonitor<Double>
+    implements Gauge<Double> {
   private final StepLong max;
   private final com.netflix.spectator.api.Gauge spectatorGauge;
 
   /**
    * Creates a new instance of the gauge.
    */
-  public MaxGauge(MonitorConfig config) {
+  public DoubleMaxGauge(MonitorConfig config) {
     this(config, ClockWithOffset.INSTANCE);
   }
 
   /**
    * Creates a new instance of the gauge using a specific clock. Useful for unit testing.
    */
-  MaxGauge(MonitorConfig config, Clock clock) {
+  DoubleMaxGauge(MonitorConfig config, Clock clock) {
     super(config.withAdditionalTag(DataSourceType.GAUGE));
-    max = new StepLong(0L, clock);
+    max = new StepLong(Double.doubleToLongBits(0.0), clock);
     spectatorGauge = SpectatorContext.maxGauge(config);
   }
 
   /**
    * Update the max for the given index if the provided value is larger than the current max.
    */
-  private void updateMax(int idx, long v) {
+  private void updateMax(int idx, double v) {
     AtomicLong current = max.getCurrent(idx);
     long m = current.get();
-    while (v > m) {
-      if (current.compareAndSet(m, v)) {
+    while (v > Double.longBitsToDouble(m)) {
+      if (current.compareAndSet(m, Double.doubleToLongBits(v))) {
         break;
       }
       m = current.get();
@@ -64,7 +64,7 @@ public class MaxGauge extends AbstractMonitor<Long>
   /**
    * Update the max if the provided value is larger than the current max.
    */
-  public void update(long v) {
+  public void update(double v) {
     spectatorGauge.set(v);
     for (int i = 0; i < Pollers.NUM_POLLERS; ++i) {
       updateMax(i, v);
@@ -75,15 +75,15 @@ public class MaxGauge extends AbstractMonitor<Long>
    * {@inheritDoc}
    */
   @Override
-  public Long getValue(int nth) {
-    return max.poll(nth);
+  public Double getValue(int nth) {
+    return Double.longBitsToDouble(max.poll(nth));
   }
 
   /**
    * Returns the current max value since the last reset.
    */
-  public long getCurrentValue(int nth) {
-    return max.getCurrent(nth).get();
+  public double getCurrentValue(int nth) {
+    return Double.longBitsToDouble(max.getCurrent(nth).get());
   }
 
   /**
@@ -94,10 +94,10 @@ public class MaxGauge extends AbstractMonitor<Long>
     if (this == obj) {
       return true;
     }
-    if (obj == null || !(obj instanceof MaxGauge)) {
+    if (obj == null || !(obj instanceof DoubleMaxGauge)) {
       return false;
     }
-    MaxGauge m = (MaxGauge) obj;
+    DoubleMaxGauge m = (DoubleMaxGauge) obj;
     return config.equals(m.getConfig()) && getValue(0).equals(m.getValue(0));
   }
 

--- a/servo-core/src/main/java/com/netflix/servo/monitor/LongGauge.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/LongGauge.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.SpectatorContext;
+
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -22,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class LongGauge extends NumberGauge {
   private final AtomicLong number;
+  private final com.netflix.spectator.api.Gauge spectatorGauge;
 
   /**
    * Create a new instance with the specified configuration.
@@ -32,12 +35,14 @@ public class LongGauge extends NumberGauge {
     super(config);
     number = new AtomicLong(0L);
     setBackingNumber(number);
+    spectatorGauge = SpectatorContext.gauge(config);
   }
 
   /**
    * Set the current value.
    */
   public void set(Long n) {
+    spectatorGauge.set(n);
     AtomicLong number = getNumber();
     number.set(n);
   }

--- a/servo-core/src/main/java/com/netflix/servo/monitor/NumberGauge.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/NumberGauge.java
@@ -15,8 +15,10 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.util.Preconditions;
+import com.netflix.spectator.api.patterns.PolledMeter;
 
 import java.lang.ref.WeakReference;
 
@@ -44,6 +46,9 @@ public class NumberGauge extends AbstractMonitor<Number> implements Gauge<Number
     super(config.withAdditionalTag(DataSourceType.GAUGE));
     Preconditions.checkNotNull(number, "number");
     this.numberRef = new WeakReference<>(number);
+    PolledMeter.using(SpectatorContext.getRegistry())
+        .withId(SpectatorContext.createId(config))
+        .monitorValue(number);
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/StepCounter.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/StepCounter.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.util.Clock;
 import com.netflix.servo.util.ClockWithOffset;
@@ -27,6 +28,7 @@ import com.netflix.servo.util.VisibleForTesting;
 public class StepCounter extends AbstractMonitor<Number> implements Counter {
 
   private final StepLong count;
+  private final com.netflix.spectator.api.Counter spectatorCounter;
 
   /**
    * Creates a new instance of the counter.
@@ -45,6 +47,7 @@ public class StepCounter extends AbstractMonitor<Number> implements Counter {
     // the publishing pipeline receiving the value.
     super(config.withAdditionalTag(DataSourceType.NORMALIZED));
     count = new StepLong(0L, clock);
+    spectatorCounter = SpectatorContext.counter(config);
   }
 
   /**
@@ -52,6 +55,7 @@ public class StepCounter extends AbstractMonitor<Number> implements Counter {
    */
   @Override
   public void increment() {
+    spectatorCounter.increment();
     count.addAndGet(1L);
   }
 
@@ -60,6 +64,7 @@ public class StepCounter extends AbstractMonitor<Number> implements Counter {
    */
   @Override
   public void increment(long amount) {
+    spectatorCounter.increment(amount);
     if (amount > 0L) {
       count.addAndGet(amount);
     }

--- a/servo-core/src/test/java/com/netflix/servo/monitor/SpectatorIntegrationTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/SpectatorIntegrationTest.java
@@ -1,0 +1,199 @@
+package com.netflix.servo.monitor;
+
+import com.netflix.servo.SpectatorContext;
+import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.annotations.Monitor;
+import com.netflix.servo.util.Clock;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Statistic;
+import com.netflix.spectator.api.patterns.PolledMeter;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class SpectatorIntegrationTest {
+
+  private static final MonitorConfig CONFIG = new MonitorConfig.Builder("test").build();
+  private static final Id ID = new DefaultRegistry()
+      .createId(CONFIG.getName())
+      .withTags(CONFIG.getTags().asMap());
+
+  private Registry registry;
+
+  @BeforeMethod
+  public void before() {
+    registry = new DefaultRegistry();
+    SpectatorContext.setRegistry(registry);
+  }
+
+  @Test
+  public void testBasicCounterIncrement() {
+    BasicCounter c = new BasicCounter(CONFIG);
+    c.increment();
+    assertEquals(1, registry.counter(ID).count());
+  }
+
+  @Test
+  public void testBasicCounterIncrementAmount() {
+    BasicCounter c = new BasicCounter(CONFIG);
+    c.increment(42);
+    assertEquals(42, registry.counter(ID).count());
+  }
+
+  @Test
+  public void testStepCounterIncrement() {
+    BasicCounter c = new BasicCounter(CONFIG);
+    c.increment();
+    assertEquals(1, registry.counter(ID).count());
+  }
+
+  @Test
+  public void testStepCounterIncrementAmount() {
+    BasicCounter c = new BasicCounter(CONFIG);
+    c.increment(42);
+    assertEquals(42, registry.counter(ID).count());
+  }
+
+  @Test
+  public void testDynamicCounterIncrement() {
+    DynamicCounter.increment(CONFIG);
+    assertEquals(1, registry.counter(ID).count());
+  }
+
+  @Test
+  public void testDoubleCounterAdd() {
+    DoubleCounter c = new DoubleCounter(CONFIG, Clock.WALL);
+    c.increment(0.2);
+    assertEquals(0.2, registry.counter(ID).actualCount());
+  }
+
+  @Test
+  public void testAnnotatedCounter() {
+    AnnotateExample ex = new AnnotateExample("foo");
+    PolledMeter.update(registry);
+    Id id = registry.createId("counter")
+        .withTag("class", "AnnotateExample")
+        .withTag("level", "INFO")
+        .withTag("id", "foo")
+        .withTag("type", "COUNTER");
+    assertEquals(1, registry.counter(id).count());
+  }
+
+  @Test
+  public void testDoubleGauge() {
+    DoubleGauge c = new DoubleGauge(CONFIG);
+    c.set(42.0);
+    assertEquals(42.0, registry.gauge(ID).value(), 1e-12);
+  }
+
+  @Test
+  public void testNumberGauge() {
+    Number n = 42.0;
+    NumberGauge c = new NumberGauge(CONFIG, n);
+    PolledMeter.update(registry);
+    assertEquals(42.0, registry.gauge(ID).value(), 1e-12);
+  }
+
+  @Test
+  public void testBasicGauge() {
+    BasicGauge<Double> c = new BasicGauge<>(CONFIG, () -> 42.0);
+    PolledMeter.update(registry);
+    assertEquals(42.0, registry.gauge(ID).value(), 1e-12);
+  }
+
+  @Test
+  public void testAnnotatedGauge() {
+    AnnotateExample ex = new AnnotateExample("foo");
+    PolledMeter.update(registry);
+    Id id = registry.createId("gauge")
+        .withTag("class", "AnnotateExample")
+        .withTag("level", "INFO")
+        .withTag("id", "foo")
+        .withTag("type", "GAUGE");
+    assertEquals(42.0, registry.gauge(id).value(), 1e-12);
+  }
+
+  @Test
+  public void testDynamicGauge() {
+    DynamicGauge.set(CONFIG, 42.0);
+    assertEquals(42.0, registry.gauge(ID).value(), 1e-12);
+  }
+
+  @Test
+  public void testDoubleMaxGauge() {
+    DoubleGauge c = new DoubleGauge(CONFIG);
+    c.set(42.0);
+    assertEquals(42.0, registry.maxGauge(ID).value(), 1e-12);
+  }
+
+  @Test
+  public void testBasicDistributionSummaryRecord() {
+    BasicDistributionSummary d = new BasicDistributionSummary(CONFIG);
+    d.record(42);
+    assertEquals(1, registry.counter(ID.withTag(Statistic.count)).count());
+    assertEquals(42, registry.counter(ID.withTag(Statistic.totalAmount)).count());
+    assertEquals(42.0, registry.maxGauge(ID.withTag(Statistic.max)).value(), 1e-12);
+  }
+
+  @Test
+  public void testBasicTimerRecordMillis() {
+    BasicTimer d = new BasicTimer(CONFIG);
+    d.record(42, TimeUnit.NANOSECONDS);
+    Id id = ID.withTag("unit", "MILLISECONDS");
+    assertEquals(1, registry.counter(id.withTag(Statistic.count)).count());
+    assertEquals(42e-6, registry.counter(id.withTag(Statistic.totalTime)).actualCount(), 1e-12);
+    assertEquals(42e-6 * 42e-6, registry.counter(id.withTag(Statistic.totalOfSquares)).actualCount(), 1e-12);
+    assertEquals(42e-6, registry.maxGauge(id.withTag(Statistic.max)).value(), 1e-12);
+  }
+
+  @Test
+  public void testBasicTimerRecordSeconds() {
+    BasicTimer d = new BasicTimer(CONFIG, TimeUnit.SECONDS);
+    d.record(42, TimeUnit.NANOSECONDS);
+    Id id = ID.withTag("unit", "SECONDS");
+    assertEquals(1, registry.counter(id.withTag(Statistic.count)).count());
+    assertEquals(42e-9, registry.counter(id.withTag(Statistic.totalTime)).actualCount(), 1e-12);
+    assertEquals(42e-9 * 42e-9, registry.counter(id.withTag(Statistic.totalOfSquares)).actualCount(), 1e-12);
+    assertEquals(42e-9, registry.maxGauge(id.withTag(Statistic.max)).value(), 1e-12);
+  }
+
+  @Test
+  public void testDynamicTimerRecordSeconds() {
+    DynamicTimer.record(CONFIG, 42);
+    Id id = ID.withTag("unit", "MILLISECONDS");
+    assertEquals(1, registry.counter(id.withTag(Statistic.count)).count());
+    assertEquals(42, registry.counter(id.withTag(Statistic.totalTime)).actualCount(), 1e-12);
+    assertEquals(42 * 42, registry.counter(id.withTag(Statistic.totalOfSquares)).actualCount(), 1e-12);
+    assertEquals(42, registry.maxGauge(id.withTag(Statistic.max)).value(), 1e-12);
+  }
+
+  public static class AnnotateExample {
+
+    private long count = 0;
+
+    private final BasicCounter c = new BasicCounter(CONFIG);
+
+    public AnnotateExample(String id) {
+      Monitors.registerObject(id, this);
+    }
+
+    @Monitor(name = "gauge", type = DataSourceType.GAUGE)
+    private double gauge() {
+      return 42.0;
+    }
+
+    @Monitor(name = "counter", type = DataSourceType.COUNTER)
+    private long counter() {
+      return count++;
+    }
+  }
+}


### PR DESCRIPTION
This is a first stab at adding a hook that will allow
updates that go to standard Servo types to be forwarded
to a Spectator registry. In most cases the updates will
be sent as they happen, e.g., the basic counter will
increment the spectator counter internally. This avoids
delays or other data quality issues.

Because so much of Servo is based on static, the main
integration point is a static reference in
SpectatorContext. The default registry is a noop
implementation so it must be set as early as possible
in the application setup.

To minimize the compatibility issues the existing
Servo implementations were changed as little as possible.
Concerns:

- Custom monitor implementations that get registered
  will currently get ignored. Will look into that later.
- User defined functions registered as gauges will now
  get called more frequently. This might cause load issues
  if they perform expensive operations inline.