### PR TITLE
Update PMD to fix InvalidSlf4jMessageFormat: NPE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ subprojects {
   }
 
   pmd {
-    toolVersion = '5.6.1'
+    toolVersion = '6.3.0'
     ignoreFailures = false
     ruleSets = []
     ruleSetFiles = rootProject.files("codequality/pmd.xml")

--- a/codequality/pmd.xml
+++ b/codequality/pmd.xml
@@ -9,7 +9,6 @@
   </description>
 
   <rule ref="rulesets/internal/all-java.xml">
-    <exclude name="AbstractNaming"/>
     <exclude name="AccessorMethodGeneration"/>
     <exclude name="AddEmptyString"/>
     <exclude name="AppendCharacterWithChar"/>
@@ -28,6 +27,7 @@
     <exclude name="AvoidUsingShortType"/>
     <exclude name="AvoidUsingVolatile"/>
     <exclude name="BeanMembersShouldSerialize"/>
+    <exclude name="ClassNamingConventions"/>
     <exclude name="CommentDefaultAccessModifier"/>
     <exclude name="CommentRequired"/>
     <exclude name="CommentSize"/>
@@ -43,12 +43,8 @@
     <exclude name="ExcessiveImports"/>
     <exclude name="ExcessivePublicCount"/>
     <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
-    <exclude name="ForLoopsMustUseBraces"/>
     <exclude name="GodClass"/>
-    <exclude name="GuardDebugLogging"/>
     <exclude name="GuardLogStatement"/>
-    <exclude name="GuardLogStatementJavaUtil"/>
-    <exclude name="IfStmtsMustUseBraces"/>
     <exclude name="ImmutableField"/>
     <exclude name="LawOfDemeter"/>
     <exclude name="LocalVariableCouldBeFinal"/>
@@ -57,7 +53,7 @@
     <exclude name="LoosePackageCoupling"/>
     <exclude name="MethodArgumentCouldBeFinal"/>
     <exclude name="MethodReturnsInternalArray"/>
-    <exclude name="ModifiedCyclomaticComplexity"/>
+    <exclude name="NcssCount"/>
     <exclude name="NullAssignment"/>
     <exclude name="OneDeclarationPerLine"/>
     <exclude name="OnlyOneReturn"/>
@@ -70,13 +66,11 @@
     <exclude name="ShortMethodName"/>
     <exclude name="ShortMethodName"/>
     <exclude name="ShortVariable"/>
-    <exclude name="StdCyclomaticComplexity"/>
     <exclude name="TooManyFields"/>
     <exclude name="TooManyMethods"/>
     <exclude name="UncommentedEmptyMethodBody"/>
     <exclude name="UnusedPrivateMethod"/>
     <exclude name="UnnecessaryConstructor"/>
-    <exclude name="UnnecessaryParentheses"/>
     <exclude name="UseConcurrentHashMap"/>
     <exclude name="UseIndexOfChar"/>
     <exclude name="UselessParentheses"/>

--- a/servo-apache/src/main/java/com/netflix/servo/publish/apache/ApacheStatusPoller.java
+++ b/servo-apache/src/main/java/com/netflix/servo/publish/apache/ApacheStatusPoller.java
@@ -87,8 +87,8 @@ public class ApacheStatusPoller extends BaseMetricPoller {
     }
   }
 
-  private static final class StatusPageParser {
-    private StatusPageParser() {
+  private static final class StatusPageParserUtil {
+    private StatusPageParserUtil() {
       // utility class
     }
 
@@ -240,7 +240,7 @@ public class ApacheStatusPoller extends BaseMetricPoller {
   List<Metric> pollImpl(long timestamp) {
     try {
       try (InputStream statusStream = fetcher.fetchStatus()) {
-        return StatusPageParser.parse(statusStream, timestamp);
+        return StatusPageParserUtil.parse(statusStream, timestamp);
       }
     } catch (IOException e) {
       logger.error("Could not fetch status page", e);

--- a/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
+++ b/servo-aws/src/main/java/com/netflix/servo/publish/cloudwatch/CloudWatchMetricObserver.java
@@ -176,6 +176,7 @@ public class CloudWatchMetricObserver extends BaseMetricObserver {
   /**
    * @param metrics The list of metrics you want to send to CloudWatch
    */
+  @Override
   public void updateImpl(List<Metric> metrics) {
     Preconditions.checkNotNull(metrics, "metrics");
 

--- a/servo-aws/src/main/java/com/netflix/servo/tag/aws/AwsInjectableTag.java
+++ b/servo-aws/src/main/java/com/netflix/servo/tag/aws/AwsInjectableTag.java
@@ -72,6 +72,7 @@ public enum AwsInjectableTag implements Tag {
   /**
    * @return Amazon compliant string representation of the key.
    */
+  @Override
   public String getKey() {
     return key;
   }
@@ -79,10 +80,12 @@ public enum AwsInjectableTag implements Tag {
   /**
    * @return value as determined at runtime for the key.
    */
+  @Override
   public String getValue() {
     return value;
   }
 
+  @Override
   public String tagString() {
     return key + "=" + value;
   }

--- a/servo-core/src/main/java/com/netflix/servo/util/Reflection.java
+++ b/servo-core/src/main/java/com/netflix/servo/util/Reflection.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2018 Netflix, Inc.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.servo.util;
 
 import java.lang.annotation.Annotation;

--- a/servo-example/src/main/java/com/netflix/servo/example/BaseHandler.java
+++ b/servo-example/src/main/java/com/netflix/servo/example/BaseHandler.java
@@ -41,6 +41,7 @@ public abstract class BaseHandler implements HttpHandler {
     Monitors.registerObject(this);
   }
 
+  @Override
   public void handle(HttpExchange exchange) throws IOException {
     CountingInputStream input = new CountingInputStream(exchange.getRequestBody());
     CountingOutputStream output = new CountingOutputStream(exchange.getResponseBody());

--- a/servo-example/src/main/java/com/netflix/servo/example/EchoHandler.java
+++ b/servo-example/src/main/java/com/netflix/servo/example/EchoHandler.java
@@ -27,6 +27,7 @@ public class EchoHandler extends BaseHandler {
     init();
   }
 
+  @Override
   protected void handleImpl(HttpExchange exchange) throws IOException {
     exchange.sendResponseHeaders(200, 0);
     ByteStreams.copy(exchange.getRequestBody(), exchange.getResponseBody());

--- a/servo-example/src/main/java/com/netflix/servo/example/ExitHandler.java
+++ b/servo-example/src/main/java/com/netflix/servo/example/ExitHandler.java
@@ -30,6 +30,7 @@ public class ExitHandler extends BaseHandler {
     init();
   }
 
+  @Override
   protected void handleImpl(HttpExchange exchange) throws IOException {
     try {
       exchange.sendResponseHeaders(200, 0);


### PR DESCRIPTION
Using version 6.3.0 fixes the NPE issue, but had other warnings enabled
that were breaking the build. Remove the `ClassNamingConvention` rule
which was forcing us to append `Util` to some publicly exposed classes.