### PR TITLE
Poll gauge values less frequently

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ subprojects {
   dependencies {
     compile 'org.slf4j:slf4j-api'
     compile 'com.google.guava:guava'
-    compile 'com.netflix.spectator:spectator-api:0.66.0'
+    compile 'com.netflix.spectator:spectator-api:0.67.0'
     testCompile 'org.testng:testng:6.1.1'
     testRuntime 'org.slf4j:slf4j-log4j12'
     testRuntime 'log4j:log4j:1.2.17'

--- a/servo-core/src/main/java/com/netflix/servo/SpectatorContext.java
+++ b/servo-core/src/main/java/com/netflix/servo/SpectatorContext.java
@@ -18,6 +18,7 @@ package com.netflix.servo;
 import com.netflix.servo.monitor.CompositeMonitor;
 import com.netflix.servo.monitor.Monitor;
 import com.netflix.servo.monitor.MonitorConfig;
+import com.netflix.servo.monitor.Pollers;
 import com.netflix.servo.monitor.SpectatorMonitor;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DistributionSummary;
@@ -32,6 +33,7 @@ import com.netflix.spectator.api.patterns.PolledMeter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -113,9 +115,11 @@ public final class SpectatorContext {
 
   /** Create builder for a polled gauge based on the config. */
   public static PolledMeter.Builder polledGauge(MonitorConfig config) {
+    long delayMillis = Math.max(Pollers.getPollingIntervals().get(0) - 1000, 5000);
     return PolledMeter.using(registry)
         .withId(createId(config))
-        .scheduleOn(GAUGE_POOL);
+        .withDelay(Duration.ofMillis(delayMillis))
+        .scheduleOn(gaugePool());
   }
 
   /** Register a custom monitor. */


### PR DESCRIPTION
Servo gauges were sampled by default once a minute, and the default
spectator polling frequency is 5s. That could cause a noticeable
increase in CPU usage attributed to monitoring. This change makes
spectator sample the values every 59s.