### PR TITLE
fix registration tags in spectator integration

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/monitor/AnnotatedNumberMonitor.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/AnnotatedNumberMonitor.java
@@ -16,6 +16,7 @@
 package com.netflix.servo.monitor;
 
 import com.netflix.servo.SpectatorContext;
+import com.netflix.servo.tag.TagList;
 import com.netflix.servo.util.Throwables;
 
 import java.lang.reflect.AccessibleObject;
@@ -59,6 +60,13 @@ class AnnotatedNumberMonitor extends AbstractMonitor<Number>
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/BasicCompositeMonitor.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/BasicCompositeMonitor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2013 Netflix, Inc.
+/*
+ * Copyright 2011-2018 Netflix, Inc.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servo-core/src/main/java/com/netflix/servo/monitor/BasicCounter.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/BasicCounter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2013 Netflix, Inc.
+/*
+ * Copyright 2011-2018 Netflix, Inc.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.netflix.servo.monitor;
 
 import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.tag.TagList;
 
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -27,14 +28,16 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class BasicCounter extends AbstractMonitor<Number>
     implements Counter, SpectatorMonitor {
+  private final MonitorConfig baseConfig;
   private final AtomicLong count = new AtomicLong();
-  private final com.netflix.spectator.api.Counter spectatorCounter;
+  private final SpectatorContext.LazyCounter spectatorCounter;
 
   /**
    * Creates a new instance of the counter.
    */
   public BasicCounter(MonitorConfig config) {
     super(config.withAdditionalTag(DataSourceType.COUNTER));
+    this.baseConfig = config;
     spectatorCounter = SpectatorContext.counter(config);
   }
 
@@ -62,6 +65,14 @@ public final class BasicCounter extends AbstractMonitor<Number>
   @Override
   public Number getValue(int pollerIdx) {
     return count.get();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+    spectatorCounter.setId(SpectatorContext.createId(baseConfig.withAdditionalTags(tags)));
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/BasicDistributionSummary.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/BasicDistributionSummary.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2014 Netflix, Inc.
+/*
+ * Copyright 2011-2018 Netflix, Inc.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.tag.BasicTagList;
 import com.netflix.servo.tag.Tag;
+import com.netflix.servo.tag.TagList;
 import com.netflix.servo.tag.Tags;
 import com.netflix.servo.util.UnmodifiableList;
 
@@ -25,7 +27,7 @@ import java.util.List;
  * Track the sample distribution of events. Similar to a BasicTimer without the time unit aspect.
  */
 public class BasicDistributionSummary
-    extends AbstractMonitor<Long> implements CompositeMonitor<Long> {
+    extends AbstractMonitor<Long> implements CompositeMonitor<Long>, SpectatorMonitor {
 
   private static final String STATISTIC = "statistic";
 
@@ -112,6 +114,16 @@ public class BasicDistributionSummary
    */
   public Long getMax() {
     return max.getCurrentValue(0);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+    totalAmount.initializeSpectator(BasicTagList.concat(tags, STAT_TOTAL));
+    count.initializeSpectator(BasicTagList.concat(tags, STAT_COUNT));
+    max.initializeSpectator(BasicTagList.concat(tags, STAT_MAX));
   }
 
   @Override

--- a/servo-core/src/main/java/com/netflix/servo/monitor/BasicGauge.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/BasicGauge.java
@@ -17,6 +17,7 @@ package com.netflix.servo.monitor;
 
 import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.tag.TagList;
 import com.netflix.servo.util.Throwables;
 
 import java.util.concurrent.Callable;
@@ -26,6 +27,8 @@ import java.util.concurrent.Callable;
  */
 public final class BasicGauge<T extends Number> extends AbstractMonitor<T>
     implements Gauge<T>, SpectatorMonitor {
+
+  private final MonitorConfig baseConfig;
   private final Callable<T> function;
 
   /**
@@ -36,9 +39,8 @@ public final class BasicGauge<T extends Number> extends AbstractMonitor<T>
    */
   public BasicGauge(MonitorConfig config, Callable<T> function) {
     super(config.withAdditionalTag(DataSourceType.GAUGE));
+    this.baseConfig = config;
     this.function = function;
-    SpectatorContext.polledGauge(config)
-        .monitorValue(this, m -> m.getValue(0).doubleValue());
   }
 
   /**
@@ -51,6 +53,15 @@ public final class BasicGauge<T extends Number> extends AbstractMonitor<T>
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+    SpectatorContext.polledGauge(baseConfig)
+        .monitorValue(this, m -> m.getValue(0).doubleValue());
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/BasicTimer.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/BasicTimer.java
@@ -15,7 +15,9 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.tag.BasicTagList;
 import com.netflix.servo.tag.Tag;
+import com.netflix.servo.tag.TagList;
 import com.netflix.servo.tag.Tags;
 import com.netflix.servo.util.Clock;
 import com.netflix.servo.util.ClockWithOffset;
@@ -169,6 +171,17 @@ public class BasicTimer extends AbstractMonitor<Long>
    */
   public Double getMax() {
     return max.getCurrentValue(0);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+    totalTime.initializeSpectator(BasicTagList.concat(tags, STAT_TOTAL));
+    count.initializeSpectator(BasicTagList.concat(tags, STAT_COUNT));
+    totalOfSquares.initializeSpectator(BasicTagList.concat(tags, STAT_TOTAL_SQ));
+    max.initializeSpectator(BasicTagList.concat(tags, STAT_MAX));
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/BucketTimer.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/BucketTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2011-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.netflix.servo.monitor;
 
 import com.netflix.servo.tag.Tag;
+import com.netflix.servo.tag.TagList;
 import com.netflix.servo.tag.Tags;
 import com.netflix.servo.util.Clock;
 import com.netflix.servo.util.ClockWithOffset;
@@ -62,7 +63,8 @@ import java.util.concurrent.TimeUnit;
  * on the use-case. If you fail to specify buckets in {@link BucketConfig} you will get a NPE.
  */
 
-public class BucketTimer extends AbstractMonitor<Long> implements Timer, CompositeMonitor<Long> {
+public class BucketTimer extends AbstractMonitor<Long>
+    implements Timer, CompositeMonitor<Long>, SpectatorMonitor {
 
   private static final String STATISTIC = "statistic";
   private static final String BUCKET = "servo.bucket";
@@ -136,6 +138,18 @@ public class BucketTimer extends AbstractMonitor<Long> implements Timer, Composi
     monitorList.addAll(Arrays.asList(bucketCount));
     monitorList.add(overflowCount);
     this.monitors = Collections.unmodifiableList(monitorList);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+    monitors.forEach(m -> {
+      if (m instanceof SpectatorMonitor) {
+        ((SpectatorMonitor) m).initializeSpectator(tags);
+      }
+    });
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/CompositeMonitorWrapper.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/CompositeMonitorWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2013 Netflix, Inc.
+/*
+ * Copyright 2011-2018 Netflix, Inc.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ import java.util.List;
 /**
  * Wraps another composite monitor object providing an alternative configuration.
  */
-class CompositeMonitorWrapper<T> extends AbstractMonitor<T> implements CompositeMonitor<T> {
+class CompositeMonitorWrapper<T>
+    extends AbstractMonitor<T> implements CompositeMonitor<T>, SpectatorMonitor {
 
   private final TagList tags;
   private final CompositeMonitor<T> monitor;
@@ -36,6 +37,9 @@ class CompositeMonitorWrapper<T> extends AbstractMonitor<T> implements Composite
     super(monitor.getConfig().withAdditionalTags(tags));
     this.tags = tags;
     this.monitor = monitor;
+    if (monitor instanceof SpectatorMonitor) {
+      ((SpectatorMonitor) monitor).initializeSpectator(tags);
+    }
   }
 
   /**
@@ -49,6 +53,15 @@ class CompositeMonitorWrapper<T> extends AbstractMonitor<T> implements Composite
       wrappedMonitors.add(Monitors.wrap(tags, m));
     }
     return Collections.unmodifiableList(wrappedMonitors);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+    // This class is only used internally when wrapping a monitor registered with
+    // Monitors.register
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/ContextualCounter.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/ContextualCounter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2013 Netflix, Inc.
+/*
+ * Copyright 2011-2018 Netflix, Inc.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servo-core/src/main/java/com/netflix/servo/monitor/ContextualTimer.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/ContextualTimer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2013 Netflix, Inc.
+/*
+ * Copyright 2011-2018 Netflix, Inc.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/servo-core/src/main/java/com/netflix/servo/monitor/DoubleGauge.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/DoubleGauge.java
@@ -18,14 +18,18 @@ package com.netflix.servo.monitor;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.tag.TagList;
+import com.netflix.spectator.api.Id;
 
 /**
  * A {@link Gauge} that reports a double value.
  */
 public class DoubleGauge extends AbstractMonitor<Double>
     implements Gauge<Double>, SpectatorMonitor {
+
+  private final MonitorConfig baseConfig;
   private final AtomicDouble number;
-  private final com.netflix.spectator.api.Gauge spectatorGauge;
+  private final SpectatorContext.LazyGauge spectatorGauge;
 
   /**
    * Create a new instance with the specified configuration.
@@ -34,6 +38,7 @@ public class DoubleGauge extends AbstractMonitor<Double>
    */
   public DoubleGauge(MonitorConfig config) {
     super(config.withAdditionalTag(DataSourceType.GAUGE));
+    baseConfig = config;
     number = new AtomicDouble(0.0);
     spectatorGauge = SpectatorContext.gauge(config);
   }
@@ -51,6 +56,15 @@ public class DoubleGauge extends AbstractMonitor<Double>
    */
   public AtomicDouble getNumber() {
     return number;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+    Id id = SpectatorContext.createId(baseConfig.withAdditionalTags(tags));
+    spectatorGauge.setId(id);
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/DynamicCounter.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/DynamicCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2011-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,8 @@ import java.util.concurrent.TimeUnit;
  * Utility class that dynamically creates counters based on an arbitrary (name, tagList), or
  * {@link MonitorConfig}. Counters are automatically expired after 15 minutes of inactivity.
  */
-public final class DynamicCounter extends AbstractMonitor<Long> implements CompositeMonitor<Long> {
+public final class DynamicCounter
+    extends AbstractMonitor<Long> implements CompositeMonitor<Long>, SpectatorMonitor {
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamicCounter.class);
   private static final String DEFAULT_EXPIRATION = "15";
   private static final String DEFAULT_EXPIRATION_UNIT = "MINUTES";
@@ -57,6 +58,13 @@ public final class DynamicCounter extends AbstractMonitor<Long> implements Compo
 
   private Counter get(final MonitorConfig config) {
     return counters.get(config);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/DynamicGauge.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/DynamicGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 Netflix, Inc.
+ * Copyright 2011-2018 Netflix, Inc.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  * or {@link com.netflix.servo.monitor.MonitorConfig}
  * Gauges are automatically expired after 15 minutes of inactivity.
  */
-public final class DynamicGauge implements CompositeMonitor<Long> {
+public final class DynamicGauge implements CompositeMonitor<Long>, SpectatorMonitor {
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamicGauge.class);
   private static final String DEFAULT_EXPIRATION = "15";
   private static final String DEFAULT_EXPIRATION_UNIT = "MINUTES";
@@ -67,6 +67,13 @@ public final class DynamicGauge implements CompositeMonitor<Long> {
         });
     cacheMonitor = Monitors.newCacheMonitor(CACHE_MONITOR_ID, gauges);
     DefaultMonitorRegistry.getInstance().register(this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/LongGauge.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/LongGauge.java
@@ -17,6 +17,8 @@ package com.netflix.servo.monitor;
 
 import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.tag.TagList;
+import com.netflix.spectator.api.Id;
 
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -25,8 +27,9 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class LongGauge extends AbstractMonitor<Long>
     implements Gauge<Long>, SpectatorMonitor {
+  private final MonitorConfig baseConfig;
   private final AtomicLong number;
-  private final com.netflix.spectator.api.Gauge spectatorGauge;
+  private final SpectatorContext.LazyGauge spectatorGauge;
 
   /**
    * Create a new instance with the specified configuration.
@@ -35,6 +38,7 @@ public class LongGauge extends AbstractMonitor<Long>
    */
   public LongGauge(MonitorConfig config) {
     super(config.withAdditionalTag(DataSourceType.GAUGE));
+    baseConfig = config;
     number = new AtomicLong(0L);
     spectatorGauge = SpectatorContext.gauge(config);
   }
@@ -53,6 +57,15 @@ public class LongGauge extends AbstractMonitor<Long>
    */
   public AtomicLong getNumber() {
     return number;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+    Id id = SpectatorContext.createId(baseConfig.withAdditionalTags(tags));
+    spectatorGauge.setId(id);
   }
 
   /**

--- a/servo-core/src/main/java/com/netflix/servo/monitor/MonitorWrapper.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/MonitorWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2013 Netflix, Inc.
+/*
+ * Copyright 2011-2018 Netflix, Inc.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,24 @@ import com.netflix.servo.tag.TagList;
  * Wraps another monitor object providing an alternative configuration.
  */
 class MonitorWrapper<T> extends AbstractMonitor<T> {
+
+  @SuppressWarnings("unchecked")
+  static <T> MonitorWrapper<T> create(TagList tags, Monitor<T> monitor) {
+    if (monitor instanceof NumericMonitor<?>) {
+      return (MonitorWrapper<T>) ((monitor instanceof SpectatorMonitor)
+          ? new SpectatorMonitorWrapper(tags, (NumericMonitor<?>) monitor)
+          : new NumericMonitorWrapper(tags, (NumericMonitor<?>) monitor));
+    } else {
+      return new MonitorWrapper<>(tags, monitor);
+    }
+  }
+
   private final Monitor<T> monitor;
 
   /**
    * Creates a new instance of the wrapper.
    */
-  public MonitorWrapper(TagList tags, Monitor<T> monitor) {
+  MonitorWrapper(TagList tags, Monitor<T> monitor) {
     super(monitor.getConfig().withAdditionalTags(tags));
     this.monitor = monitor;
   }

--- a/servo-core/src/main/java/com/netflix/servo/monitor/Monitors.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/Monitors.java
@@ -239,10 +239,8 @@ public final class Monitors {
     Monitor<T> m;
     if (monitor instanceof CompositeMonitor<?>) {
       m = new CompositeMonitorWrapper<>(tags, (CompositeMonitor<T>) monitor);
-    } else if (monitor instanceof NumericMonitor<?>) {
-      m = (Monitor<T>) new NumericMonitorWrapper(tags, (NumericMonitor<?>) monitor);
     } else {
-      m = new MonitorWrapper<>(tags, monitor);
+      m = MonitorWrapper.create(tags, monitor);
     }
     return m;
   }

--- a/servo-core/src/main/java/com/netflix/servo/monitor/SpectatorMonitor.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/SpectatorMonitor.java
@@ -15,10 +15,18 @@
  */
 package com.netflix.servo.monitor;
 
+import com.netflix.servo.tag.TagList;
+
 /**
  * Indicates that the monitor implementation will automatically update the spectator
  * registry defined in {@code SpectatorContext}. Other monitors need to get polled and
  * update the registry.
  */
 public interface SpectatorMonitor {
+
+  /**
+   * Servo registration can add tags based on the context. This method will be called
+   * during the registration to apply that context to the underlying Spectator ids.
+   */
+  void initializeSpectator(TagList tags);
 }

--- a/servo-core/src/main/java/com/netflix/servo/monitor/SpectatorMonitorWrapper.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/SpectatorMonitorWrapper.java
@@ -1,0 +1,21 @@
+package com.netflix.servo.monitor;
+
+import com.netflix.servo.tag.TagList;
+
+class SpectatorMonitorWrapper<T extends Number>
+    extends NumericMonitorWrapper<T> implements SpectatorMonitor {
+
+  SpectatorMonitorWrapper(TagList tags, NumericMonitor<T> monitor) {
+    super(tags, monitor);
+    if (monitor instanceof SpectatorMonitor) {
+      ((SpectatorMonitor) monitor).initializeSpectator(tags);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+  }
+}

--- a/servo-core/src/main/java/com/netflix/servo/monitor/StatsMonitor.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/StatsMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2011-2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import com.netflix.servo.stats.StatsBuffer;
 import com.netflix.servo.stats.StatsConfig;
 import com.netflix.servo.tag.BasicTagList;
 import com.netflix.servo.tag.Tag;
+import com.netflix.servo.tag.TagList;
 import com.netflix.servo.tag.Tags;
 import com.netflix.servo.util.Clock;
 import com.netflix.servo.util.ThreadFactories;
@@ -46,7 +47,7 @@ import java.util.stream.Collectors;
  * specified by the user using a {@link com.netflix.servo.stats.StatsConfig} object.
  */
 public class StatsMonitor extends AbstractMonitor<Long> implements
-    CompositeMonitor<Long>, NumericMonitor<Long> {
+    CompositeMonitor<Long>, NumericMonitor<Long>, SpectatorMonitor {
 
   protected static final ScheduledExecutorService DEFAULT_EXECUTOR;
   private static final long EXPIRE_AFTER_MS;
@@ -366,6 +367,18 @@ public class StatsMonitor extends AbstractMonitor<Long> implements
     if (autoStart) {
       startComputingStats();
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+    monitors.forEach(m -> {
+      if (m instanceof SpectatorMonitor) {
+        ((SpectatorMonitor) m).initializeSpectator(tags);
+      }
+    });
   }
 
   void computeStats() {

--- a/servo-core/src/main/java/com/netflix/servo/monitor/StepCounter.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/StepCounter.java
@@ -17,9 +17,11 @@ package com.netflix.servo.monitor;
 
 import com.netflix.servo.SpectatorContext;
 import com.netflix.servo.annotations.DataSourceType;
+import com.netflix.servo.tag.TagList;
 import com.netflix.servo.util.Clock;
 import com.netflix.servo.util.ClockWithOffset;
 import com.netflix.servo.util.VisibleForTesting;
+import com.netflix.spectator.api.Id;
 
 /**
  * A simple counter implementation backed by a StepLong. The value returned is a rate for the
@@ -27,8 +29,9 @@ import com.netflix.servo.util.VisibleForTesting;
  */
 public class StepCounter extends AbstractMonitor<Number> implements Counter, SpectatorMonitor {
 
+  private final MonitorConfig baseConfig;
   private final StepLong count;
-  private final com.netflix.spectator.api.Counter spectatorCounter;
+  private SpectatorContext.LazyCounter spectatorCounter;
 
   /**
    * Creates a new instance of the counter.
@@ -46,6 +49,7 @@ public class StepCounter extends AbstractMonitor<Number> implements Counter, Spe
     // expected for type=COUNTER. This class looks like a counter to the user and a gauge to
     // the publishing pipeline receiving the value.
     super(config.withAdditionalTag(DataSourceType.NORMALIZED));
+    this.baseConfig = config;
     count = new StepLong(0L, clock);
     spectatorCounter = SpectatorContext.counter(config);
   }
@@ -93,6 +97,15 @@ public class StepCounter extends AbstractMonitor<Number> implements Counter, Spe
   @VisibleForTesting
   public long getCurrentCount(int pollerIndex) {
     return count.getCurrent(pollerIndex).get();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void initializeSpectator(TagList tags) {
+    Id id = SpectatorContext.createId(baseConfig.withAdditionalTags(tags));
+    spectatorCounter.setId(id);
   }
 
   /**


### PR DESCRIPTION
Before we would always set the spectator id based on the
initial config. For uses cases where a monitor field is
registered, the tags get update with the class and possibly
and id. Servo does this with a wrapper that changes the
id. For Spectator we need to be able to update the id and
fetch a new instance of the underlying meter that will get
updated.

Now the SpectatorMonitor interface allows the additional
tags to be set in an initialization call that happens as
part of the registration. The meter types are lazy so it
will not actually create them until the first activity
occurs which should be post-registration if they are using
Servo correctly.