### PR TITLE
base StatsMonitor expiration on writes

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/monitor/StatsMonitor.java
+++ b/servo-core/src/main/java/com/netflix/servo/monitor/StatsMonitor.java
@@ -435,14 +435,6 @@ public class StatsMonitor extends AbstractMonitor<Long> implements
    */
   @Override
   public List<Monitor<?>> getMonitors() {
-    lastUsed = clock.now();
-    if (isExpired()) {
-      LOGGER.info("Attempting to get the value for an expired monitor: {}."
-              + "Will start computing stats again.",
-          getConfig().getName());
-      startComputingStats(executor, statsConfig.getFrequencyMillis());
-      return Collections.emptyList();
-    }
     return monitors;
   }
 
@@ -450,6 +442,14 @@ public class StatsMonitor extends AbstractMonitor<Long> implements
    * Record the measurement we want to perform statistics on.
    */
   public void record(long measurement) {
+    lastUsed = clock.now();
+    if (isExpired()) {
+      LOGGER.info("Attempting to get the value for an expired monitor: {}."
+              + "Will start computing stats again.",
+          getConfig().getName());
+      startComputingStats(executor, statsConfig.getFrequencyMillis());
+    }
+
     synchronized (updateLock) {
       cur.record(measurement);
     }

--- a/servo-core/src/test/java/com/netflix/servo/monitor/StatsMonitorTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/StatsMonitorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015 Netflix, Inc.
+/*
+ * Copyright 2011-2018 Netflix, Inc.
  * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class StatsMonitorTest {
     clock.set(TimeUnit.MINUTES.toMillis(20));
     monitor.computeStats();
     assertTrue(monitor.isExpired());
-    monitor.getMonitors();
+    monitor.record(42);
     monitor.computeStats();
     assertFalse(monitor.isExpired());
   }


### PR DESCRIPTION
Before it was using calls to `getMonitors` to update the
last used time. That method will not get called when
delegating to Spectator and thus it will always expire
15 minutes after registration and never come back.

This changes the last used time to get updated when
values are recorded rather than when they are read using
`getMonitors`.