### PR TITLE
warn if SpectatorContext registry is overwritten

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/SpectatorContext.java
+++ b/servo-core/src/main/java/com/netflix/servo/SpectatorContext.java
@@ -88,9 +88,8 @@ public final class SpectatorContext {
       e.fillInStackTrace();
       initStacktrace = e;
       if (cause != null) {
-        LOGGER.warn(
-            "Registry used with Servo's SpectatorContext has been overwritten. This could " +
-            "result in missing metrics.", e);
+        LOGGER.warn("Registry used with Servo's SpectatorContext has been overwritten. This could "
+            + "result in missing metrics.", e);
       }
     }
   }


### PR DESCRIPTION
Adds a warning level log message if the registry used with
the SpectatorContext is overwritten. This should help with
debugging cases where Servo metrics are not being reported
properly because of initialization bugs in the application.