### PR TITLE
add a checkArgument that avoids varargs 

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/util/Preconditions.java
+++ b/servo-core/src/main/java/com/netflix/servo/util/Preconditions.java
@@ -43,7 +43,28 @@ public final class Preconditions {
      * @throws IllegalArgumentException if {@code expression} is false
      */
   public static void checkArgument(boolean expression, String errorMessage) {
-    checkArgument(expression, errorMessage, null);
+    checkArgument(expression, errorMessage, (String) null);
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the
+   * calling method.
+   *
+   *
+   * @param expression a boolean expression
+   * @param errorMessage the error message that can be a formattable string
+   * @param arg argument if using a formatted string
+   * @throws IllegalArgumentException if {@code expression} is false
+   */
+  public static void checkArgument(boolean expression, String errorMessage, String arg) {
+    if (!expression) {
+      if (arg != null) {
+        String message = String.format(errorMessage, arg);
+        throw new IllegalArgumentException(message);
+      } else {
+        throw new IllegalArgumentException(errorMessage);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
and the allocation overhead of creating a string array

during application profiling found that some allocation can be avoided if we explicitly invoke the checkArgument method without varargs

Allocation profiling via async-profiler:
```
--- 1451114625215846968 bytes (21.40%), 10371 samples
  [ 0] java.lang.String[]
  [ 1] com.netflix.servo.tag.BasicTag.checkNotEmpty
  [ 2] com.netflix.servo.tag.BasicTag.<init>
  [ 3] com.netflix.servo.tag.Tags.newTag
  [ 4] com.netflix.servo.monitor.MonitorConfig$Builder.withTag
```