### PR TITLE
switch to no op monitor registry by default

### DIFF
--- a/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/DefaultMonitorRegistry.java
@@ -86,7 +86,6 @@ public final class DefaultMonitorRegistry implements MonitorRegistry {
                   + NoopMonitorRegistry.class.getName(),
               t);
           r = new NoopMonitorRegistry();
-          throw new RuntimeException(t);
         }
       }
       registry = r;

--- a/servo-core/src/main/java/com/netflix/servo/NoopMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/NoopMonitorRegistry.java
@@ -25,6 +25,7 @@ import java.util.Collections;
  */
 public class NoopMonitorRegistry implements MonitorRegistry {
 
+  /** Create a new instance. */
   public NoopMonitorRegistry() {
   }
 

--- a/servo-core/src/main/java/com/netflix/servo/NoopMonitorRegistry.java
+++ b/servo-core/src/main/java/com/netflix/servo/NoopMonitorRegistry.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.servo;
+
+import com.netflix.servo.monitor.Monitor;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Monitor registry implementation that does as little as possible.
+ */
+public class NoopMonitorRegistry implements MonitorRegistry {
+
+  public NoopMonitorRegistry() {
+  }
+
+  @Override
+  public Collection<Monitor<?>> getRegisteredMonitors() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void register(Monitor<?> monitor) {
+  }
+
+  @Override
+  public void unregister(Monitor<?> monitor) {
+  }
+
+  @Override
+  public boolean isRegistered(Monitor<?> monitor) {
+    return false;
+  }
+}

--- a/servo-core/src/test/java/com/netflix/servo/DefaultMonitorRegistryTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/DefaultMonitorRegistryTest.java
@@ -32,6 +32,8 @@ public class DefaultMonitorRegistryTest {
   @Test
   public void testCustomJmxObjectMapper() {
     Properties props = new Properties();
+    props.put("com.netflix.servo.DefaultMonitorRegistry.registryClass",
+        "com.netflix.servo.jmx.JmxMonitorRegistry");
     props.put("com.netflix.servo.DefaultMonitorRegistry.jmxMapperClass",
         "com.netflix.servo.DefaultMonitorRegistryTest$ChangeDomainMapper");
     DefaultMonitorRegistry registry = new DefaultMonitorRegistry(props);
@@ -47,6 +49,8 @@ public class DefaultMonitorRegistryTest {
   @Test
   public void testInvalidMapperDefaults() {
     Properties props = new Properties();
+    props.put("com.netflix.servo.DefaultMonitorRegistry.registryClass",
+        "com.netflix.servo.jmx.JmxMonitorRegistry");
     props.put("com.netflix.servo.DefaultMonitorRegistry.jmxMapperClass",
         "com.my.invalid.class");
     DefaultMonitorRegistry registry = new DefaultMonitorRegistry(props);

--- a/servo-core/src/test/java/com/netflix/servo/monitor/MonitorsTest.java
+++ b/servo-core/src/test/java/com/netflix/servo/monitor/MonitorsTest.java
@@ -99,14 +99,6 @@ public class MonitorsTest {
   }
 
   @Test
-  public void testIsRegistered() throws Exception {
-    ClassWithMonitors obj = new ClassWithMonitors();
-    assertFalse(Monitors.isObjectRegistered("id", obj));
-    Monitors.registerObject("id", obj);
-    assertTrue(Monitors.isObjectRegistered("id", obj));
-  }
-
-  @Test
   public void testNewObjectConfig() throws Exception {
     ClassWithMonitors obj = new ClassWithMonitors() {
     };


### PR DESCRIPTION
Internally Servo is deprecated and delegates to Spectator.
This change would reduce the overhead for things that are
still using the Servo APIs. The main benefit is that the
data would no longer be exported to JMX.

Note, this could be quite disruptive to anyone else using
Servo. Since it is all setup via sytem properties, there
isn't a convenient way to only change the default we use
internally.

After making this change, I noticed that loading the JMX
monitor registry explicitly using the property no longer
worked. That has been fixed so the old behavior can be
acheived using a system property.