### PR TITLE
ci: use Temurin distributions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 15]
+        java: [8, 11, 17]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'zulu'
+          distribution: 'temurin'
       - uses: actions/cache@v2
         id: gradle-cache
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 8
-          distribution: 'zulu'
+          distribution: 'temurin'
       - uses: actions/cache@v2
         id: gradle-cache
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 8
-          distribution: 'zulu'
+          distribution: 'temurin'
       - uses: actions/cache@v2
         id: gradle-cache
         with:


### PR DESCRIPTION
Host runners include Temurin by default as part of the [hosted tool cache ](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#hosted-tool-cache)

Using Temurin speeds up builds as there is no need to download and configure the Java SDK with every build.